### PR TITLE
fix: Files overwritten via `Mstsc` may trigger auto-reload with IO exceptions

### DIFF
--- a/managed/src/SwiftlyS2.Core/Modules/Plugins/PluginManager.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/Plugins/PluginManager.cs
@@ -79,6 +79,11 @@ internal class PluginManager
   {
     try
     {
+      if (!NativeServerHelpers.UseAutoHotReload())
+      {
+        return;
+      }
+
       // Windows FileSystemWatcher triggers multiple (open, write, close) events for a single file change
       if (DateTime.Now - lastRead < TimeSpan.FromSeconds(1))
       {

--- a/managed/src/SwiftlyS2.Generated/Natives/ServerHelpers.cs
+++ b/managed/src/SwiftlyS2.Generated/Natives/ServerHelpers.cs
@@ -38,4 +38,11 @@ internal static class NativeServerHelpers {
     var ret = _IsFollowingServerGuidelines();
     return ret == 1;
   }
+
+  private unsafe static delegate* unmanaged<byte> _UseAutoHotReload;
+
+  public unsafe static bool UseAutoHotReload() {
+    var ret = _UseAutoHotReload();
+    return ret == 1;
+  }
 }

--- a/natives/server/helpers.native
+++ b/natives/server/helpers.native
@@ -3,3 +3,4 @@ class ServerHelpers
 string GetServerLanguage = void
 bool UsePlayerLanguage = void
 bool IsFollowingServerGuidelines = void
+bool UseAutoHotReload = void

--- a/plugin_files/configs/core.example.jsonc
+++ b/plugin_files/configs/core.example.jsonc
@@ -6,6 +6,7 @@
     "CommandSilentPrefixes": [
         "/"
     ],
+    "AutoHotReload": true,
     "ConsoleFilter": true,
     "FollowCS2ServerGuidelines": true,
     "Language": "en",

--- a/src/scripting/server/helpers.cpp
+++ b/src/scripting/server/helpers.cpp
@@ -43,6 +43,13 @@ bool Bridge_ServerHelpers_IsFollowingServerGuidelines()
     return std::get<bool>(configuration->GetValue("core.FollowCS2ServerGuidelines"));
 }
 
+bool Bridge_ServerHelpers_UseAutoHotReload()
+{
+    static auto configuration = g_ifaceService.FetchInterface<IConfiguration>(CONFIGURATION_INTERFACE_VERSION);
+    return std::get<bool>(configuration->GetValue("core.AutoHotReload"));
+}
+
 DEFINE_NATIVE("ServerHelpers.GetServerLanguage", Bridge_ServerHelpers_GetServerLanguage);
 DEFINE_NATIVE("ServerHelpers.UsePlayerLanguage", Bridge_ServerHelpers_UsePlayerLanguage);
 DEFINE_NATIVE("ServerHelpers.IsFollowingServerGuidelines", Bridge_ServerHelpers_IsFollowingServerGuidelines);
+DEFINE_NATIVE("ServerHelpers.UseAutoHotReload", Bridge_ServerHelpers_UseAutoHotReload);

--- a/src/server/configuration/configuration.cpp
+++ b/src/server/configuration/configuration.cpp
@@ -462,6 +462,7 @@ bool Configuration::Load()
 
         RegisterConfigurationVector<std::string>(wasEdited, config_json, "core", "core", "CommandPrefixes", { "!" }, true, " ");
         RegisterConfigurationVector<std::string>(wasEdited, config_json, "core", "core", "CommandSilentPrefixes", { "/" }, true, " ");
+        RegisterConfiguration(wasEdited, config_json, "core", "core", "AutoHotReload", true);
         RegisterConfiguration(wasEdited, config_json, "core", "core", "ConsoleFilter", true);
         RegisterConfigurationVector<std::string>(wasEdited, config_json, "core", "core", "PatchesToPerform", {}, true, " ");
 


### PR DESCRIPTION
## Description

Introduce configuration for plugin auto-reload system.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] Build/CI improvement

## Related Issues

Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)

## Changes Made

- [x] Native changes (C++)
- [x] Managed Changes (C#)
- [x] API additions/modifications
- [ ] Memory management improvements
- [ ] Network handling changes
- [ ] SDK updates
- [ ] Build system changes

### Detailed Changes

List the specific changes made:

- Updated `core.example.jsonc` with new plugin auto-reload configuration section

## Testing

### Test Environment

- **OS**: Windows 11
- **Game**: Counter-Strike 2

### Test Cases

Describe the test cases you've run:

1.
2.
3.

## Breaking Changes

List any breaking changes and migration steps:

- 

## Performance Impact

- [ ] No performance impact
- [ ] Positive performance impact
- [ ] Negative performance impact (explain below)
- [x] Performance impact unknown

Details:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots/Videos (if applicable)

Add screenshots or videos demonstrating the changes:

N/A

## Additional Notes

Any additional information, context, or notes for reviewers:

---

### For Maintainers

- [ ] Code review completed
- [ ] Tests pass
- [ ] Ready to merge