### PR TITLE
fix: Prevent OOM in logger by limiting `AnsiConsole.Profile.Width`

### DIFF
--- a/managed/src/SwiftlyS2.Core/Misc/SwiftlyLogger.cs
+++ b/managed/src/SwiftlyS2.Core/Misc/SwiftlyLogger.cs
@@ -35,7 +35,7 @@ internal class SwiftlyLogger( string categoryName, string contextName ) : ILogge
         var timestamp = DateTime.Now.ToString("MM/dd HH:mm:ss");
         var (levelText, color) = LogLevelConfig.TryGetValue(logLevel, out var config) ? config : ("Unknown", "grey42");
         var eventIdText = eventId.Id != 0 ? $"[{eventId.Id}]" : string.Empty;
-        AnsiConsole.Profile.Width = int.MaxValue;
+        AnsiConsole.Profile.Width = 13337;
 
         // Console output
         AnsiConsole.MarkupLineInterpolated($"[lightsteelblue1 bold]{contextName}[/] [lightsteelblue]|[/] [grey42]{timestamp}[/] [lightsteelblue]|[/] [{color}]{levelText}[/] [lightsteelblue]|[/] [lightsteelblue]{categoryName}{eventIdText}[/]");


### PR DESCRIPTION
## Description

revent OOM in logger by limiting `AnsiConsole.Profile.Width`.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] Build/CI improvement

## Related Issues

Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)

## Changes Made

- [ ] Native changes (C++)
- [ ] Managed Changes (C#)
- [ ] API additions/modifications
- [ ] Memory management improvements
- [ ] Network handling changes
- [ ] SDK updates
- [ ] Build system changes

### Detailed Changes

List the specific changes made:

- 
- 
- 

## Testing

### Test Environment

- **OS**: (e.g., Windows 11, Ubuntu 22.04)
- **Game**: (e.g., Counter-Strike 2)

### Test Cases

Describe the test cases you've run:

1. 
2. 
3. 

## Breaking Changes

List any breaking changes and migration steps:

- 
- 

## Performance Impact

- [ ] No performance impact
- [ ] Positive performance impact
- [ ] Negative performance impact (explain below)
- [ ] Performance impact unknown

Details:

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots/Videos (if applicable)

Add screenshots or videos demonstrating the changes:

## Additional Notes

Any additional information, context, or notes for reviewers:

---

### For Maintainers

- [ ] Code review completed
- [ ] Tests pass
- [ ] Ready to merge
