### PR TITLE
Fix: check PDB file access when hot reload

### DIFF
--- a/managed/src/SwiftlyS2.Core/Modules/Plugins/PluginManager.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/Plugins/PluginManager.cs
@@ -58,11 +58,6 @@ internal class PluginManager : IPluginManager
         {
             static async Task WaitForFileAccess( CancellationToken token, string filePath, int maxRetries = 10, int initialDelayMs = 50, ILogger<PluginManager> logger = null )
             {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    logger.LogWarning("Detected Linux OS, a 5 second delay for reload.");
-                    await Task.Delay(5000, token);
-                }
                 for (var i = 1; i <= maxRetries && !token.IsCancellationRequested; i++)
                 {
                     try
@@ -139,13 +134,20 @@ internal class PluginManager : IPluginManager
                     {
                         try
                         {
-                            await Task.Delay(300, cts.Token);
+                            var wait = 300;
+                            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                            {
+                                logger.LogWarning("Detected Linux OS, a 5 second delay for reload.");
+                            }
+                            await Task.Delay(wait, cts.Token);
+
                             await WaitForFileAccess(cts.Token, e.FullPath, logger: logger);
                             var pdbFile = Path.ChangeExtension(e.FullPath, ".pdb");
                             if (File.Exists(pdbFile))
                             {
                                 await WaitForFileAccess(cts.Token, pdbFile, logger: logger);
                             }
+
                             Console.WriteLine("\n");
                             if (ReloadPluginByDllName(directoryName, true))
                             {


### PR DESCRIPTION
## Description
Personally I use my own tool to automatically quick copy updated dll+pdb files after compiled.   
and I often got `failed to load plugin ... because PDB is being used by another process.` when I hot reload my plugin.   
It really became a problem since I have to restart the server to continue.  

My solution is to delay the plugin reload and give PDB file a file access test.    

```cs
SwiftlyS2 | 12-26 11:10:06 | Warning | SwiftlyS2.Core.Plugins.PluginManager
SwiftlyS2 | Failed to load plugin by name: C:\Users\Buyi\Apps\cs2\game\csgo\addons\swiftlys2\plugins\MyPluginName
System.IO.IOException: The process cannot access the file 'C:\Users\Buyi\Apps\cs2\game\csgo\addons\swiftlys2\plugins\MyPluginName\MyPluginName.pdb' because it is being used by another process.
  at System.IO.Strategies.OSFileStreamStrategy..ctor(string path, FileMode mode, FileAccess access, FileShare share, FileOptions options, long preallocationSize, UnixFileMode? unixCreateMode)
  at FileStream System.IO.File.Open(string path, FileMode mode, FileAccess access, FileShare share)                                     
  at Assembly McMaster.NETCore.Plugins.Loader.ManagedLoadContext.LoadAssemblyFromFilePath(string path)                                  
  at Assembly McMaster.NETCore.Plugins.PluginLoader.LoadDefaultAssembly()                                                               
  at PluginContext SwiftlyS2.Core.Plugins.PluginManager.LoadPlugin(string dir, bool hotReload, bool silent) in                          
     C:\Users\Buyi\source\repos\alliedmodders\swiftlys2\managed\src\SwiftlyS2.Core\Modules\Plugins\PluginManager.cs:538                 
  at bool SwiftlyS2.Core.Plugins.PluginManager.LoadPluginByDllName(string dllName, bool silent) in C:\Users\Buyi\source\repos\alliedmodders\swiftlys2\managed\src\SwiftlyS2.Core\Modules\Plugins\
     PluginManager.cs:332                                                                                                               
SwiftlyS2 | 12-26 11:10:06 | Warning | SwiftlyS2.Core.Plugins.PluginManager
SwiftlyS2 | Failed to reload plugin: MyPluginName
```

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] Build/CI improvement

## Related Issues

Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)

## Changes Made

- [ ] Native changes (C++)
- [x] Managed Changes (C#)
- [ ] API additions/modifications
- [ ] Memory management improvements
- [ ] Network handling changes
- [ ] SDK updates
- [ ] Build system changes

### Detailed Changes

List the specific changes made:

- 
- 
- 

## Testing

### Test Environment

- **OS**: (e.g., Windows 11, Ubuntu 22.04)
- **Game**: (e.g., Counter-Strike 2)

### Test Cases

Describe the test cases you've run:

1. 
2. 
3. 

## Breaking Changes

List any breaking changes and migration steps:

- 
- 

## Performance Impact

- [ ] No performance impact
- [ ] Positive performance impact
- [ ] Negative performance impact (explain below)
- [ ] Performance impact unknown

Details:

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots/Videos (if applicable)

Add screenshots or videos demonstrating the changes:

## Additional Notes

Any additional information, context, or notes for reviewers:

---

### For Maintainers

- [ ] Code review completed
- [ ] Tests pass
- [ ] Ready to merge
