### PR TITLE
feat(events): IsListeningToEvent

### DIFF
--- a/managed/src/SwiftlyS2.Core/Modules/GameEvents/GameEventService.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/GameEvents/GameEventService.cs
@@ -193,9 +193,14 @@ internal class GameEventService : IGameEventService, IDisposable
         return SchedulerManager.QueueOrNow(() => FireToServer(configureEvent));
     }
 
-    public bool IsListeningToEventName( int slot, string eventName )
+    public bool IsListeningToEvent( int slot, string eventName )
     {
         return NativeGameEvents.IsPlayerListeningToEventName(slot, eventName);
+    }
+
+    public bool IsListeningToEvent<T>( int slot ) where T : IGameEvent<T>
+    {
+        return IsListeningToEvent(slot, T.GetName());
     }
 
     public void Dispose()

--- a/managed/src/SwiftlyS2.Shared/Modules/GameEvents/IGameEventService.cs
+++ b/managed/src/SwiftlyS2.Shared/Modules/GameEvents/IGameEventService.cs
@@ -154,5 +154,12 @@ public interface IGameEventService
     /// </summary>
     /// <param name="slot">The player slot.</param>
     /// <param name="eventName">The event name.</param>
-    bool IsListeningToEventName( int slot, string eventName );
+    bool IsListeningToEvent( int slot, string eventName );
+
+    /// <summary>
+    /// Check if the player is Listening this event.
+    /// </summary>
+    /// <typeparam name="T">The event type.</typeparam>
+    /// <param name="slot">The player slot.</param>
+    bool IsListeningToEvent<T>( int slot ) where T : IGameEvent<T>;
 }


### PR DESCRIPTION
This pull request adds new methods to the game event service, allowing the system to check if a player is currently listening to a specific game event by name or by event type. These changes improve the flexibility and type safety of event listening checks.

**Game event listening checks:**

* Added `IsListeningToEvent(int slot, string eventName)` and `IsListeningToEvent<T>(int slot)` methods to the `IGameEventService` interface, enabling checks for whether a player is listening to a specific event by name or by generic event type.
* Implemented the new methods in `GameEventService`, utilizing `NativeGameEvents.IsPlayerListeningToEventName` for the underlying check.