### PR TITLE
Merge defaults into plugin JSON/TOML configs

### DIFF
--- a/managed/src/SwiftlyS2.Core/Services/PluginConfigurationService.cs
+++ b/managed/src/SwiftlyS2.Core/Services/PluginConfigurationService.cs
@@ -1,10 +1,12 @@
 using System.Data.Common;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Extensions.Configuration;
 using SwiftlyS2.Core.Natives;
 using SwiftlyS2.Core.Services;
 using SwiftlyS2.Shared.Services;
 using Tomlyn;
+using Tomlyn.Model;
 
 namespace SwiftlyS2.Core.Services;
 
@@ -71,25 +73,13 @@ internal class PluginConfigurationService : IPluginConfigurationService
 
   public IPluginConfigurationService InitializeJsonWithModel<T>( string name, string sectionName ) where T : class, new()
   {
-
     var configPath = GetConfigPath(name);
-
-    if (File.Exists(configPath))
-    {
-      return this;
-    }
 
     var dir = Path.GetDirectoryName(configPath);
     if (dir is not null)
     {
       Directory.CreateDirectory(dir);
     }
-
-    var config = new T();
-
-    var wrapped = new Dictionary<string, object?> {
-      [sectionName] = config
-    };
 
     var options = new JsonSerializerOptions {
       WriteIndented = true,
@@ -97,21 +87,66 @@ internal class PluginConfigurationService : IPluginConfigurationService
       PropertyNamingPolicy = null
     };
 
-    var configJson = JsonSerializer.Serialize(wrapped, options);
-    File.WriteAllText(configPath, configJson);
+    var defaults = new Dictionary<string, object?> { [sectionName] = new T() };
+    var defaultJson = JsonSerializer.SerializeToNode(defaults, options)!.AsObject();
+
+    if (!File.Exists(configPath))
+    {
+      File.WriteAllText(configPath, defaultJson.ToJsonString(options));
+      return this;
+    }
+
+    var existingText = File.ReadAllText(configPath);
+    JsonNode? existingNode;
+    try
+    {
+      existingNode = JsonNode.Parse(existingText);
+    }
+    catch (JsonException)
+    {
+      existingNode = null;
+    }
+
+    if (existingNode is not JsonObject existingObj)
+    {
+      File.WriteAllText(configPath, defaultJson.ToJsonString(options));
+      return this;
+    }
+
+    if (MergeJsonObjects(existingObj, defaultJson))
+    {
+      File.WriteAllText(configPath, existingObj.ToJsonString(options));
+    }
 
     return this;
   }
 
+  private static bool MergeJsonObjects( JsonObject target, JsonObject defaults )
+  {
+    var changed = false;
+
+    foreach (var (key, defaultValue) in defaults)
+    {
+      if (!target.ContainsKey(key))
+      {
+        target[key] = defaultValue?.DeepClone();
+        changed = true;
+      }
+      else if (defaultValue is JsonObject defaultChild && target[key] is JsonObject targetChild)
+      {
+        if (MergeJsonObjects(targetChild, defaultChild))
+        {
+          changed = true;
+        }
+      }
+    }
+
+    return changed;
+  }
+
   public IPluginConfigurationService InitializeTomlWithModel<T>( string name, string sectionName ) where T : class, new()
   {
-
     var configPath = GetConfigPath(name);
-
-    if (File.Exists(configPath))
-    {
-      return this;
-    }
 
     var dir = Path.GetDirectoryName(configPath);
     if (dir is not null)
@@ -119,21 +154,68 @@ internal class PluginConfigurationService : IPluginConfigurationService
       Directory.CreateDirectory(dir);
     }
 
-    var config = new T();
-
-    var wrapped = new Dictionary<string, object?> {
-      [sectionName] = config
-    };
-
     var tomlModelOptions = new TomlModelOptions {
-      ConvertPropertyName = name => name,
+      ConvertPropertyName = n => n,
       IgnoreMissingProperties = true
     };
 
-    var tomlString = Toml.FromModel(wrapped, tomlModelOptions);
-    File.WriteAllText(configPath, tomlString);
+    var defaults = new Dictionary<string, object?> { [sectionName] = new T() };
+    var defaultToml = Toml.FromModel(defaults, tomlModelOptions);
+
+    if (!File.Exists(configPath))
+    {
+      File.WriteAllText(configPath, defaultToml);
+      return this;
+    }
+
+    var existingText = File.ReadAllText(configPath);
+    TomlTable? existingTable;
+    try
+    {
+      existingTable = Toml.ToModel(existingText);
+    }
+    catch
+    {
+      existingTable = null;
+    }
+
+    var defaultTable = Toml.ToModel(defaultToml);
+
+    if (existingTable is null)
+    {
+      File.WriteAllText(configPath, defaultToml);
+      return this;
+    }
+
+    if (MergeTomlTables(existingTable, defaultTable))
+    {
+      File.WriteAllText(configPath, Toml.FromModel(existingTable, tomlModelOptions));
+    }
 
     return this;
+  }
+
+  private static bool MergeTomlTables( TomlTable target, TomlTable defaults )
+  {
+    var changed = false;
+
+    foreach (var (key, defaultValue) in defaults)
+    {
+      if (!target.ContainsKey(key))
+      {
+        target[key] = defaultValue;
+        changed = true;
+      }
+      else if (defaultValue is TomlTable defaultChild && target[key] is TomlTable targetChild)
+      {
+        if (MergeTomlTables(targetChild, defaultChild))
+        {
+          changed = true;
+        }
+      }
+    }
+
+    return changed;
   }
 
   public IPluginConfigurationService Configure( Action<IConfigurationBuilder> configure )


### PR DESCRIPTION
## Description

Brief description of the changes introduced by this pull request.

## Type of Change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)


## Related Issues

Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)

## Changes Made

- [x] Managed Changes (C#)


### Detailed Changes

List the specific changes made:

Config initialization now merges in any missing default keys from model, for both JSON and TOML, without overwriting existing user values. Updates are applied recursively, so nested sections get patched too. The config file is only rewritten when at least one new key is added.

## Testing

### Test Environment

- **OS**: Windows 11. Ubuntu 25.04 
- **Game**: (e.g., Counter-Strike 2)

### Test Cases

Describe the test cases you've run:

1. Tested with VIPCore old config version that contained "Delay" and on the new version I removed the value and replaced with the ServerId. On the test the config removed the old Delay value and replaced with ServerId as expected.  
2. 
3. 

## Breaking Changes

List any breaking changes and migration steps:

- 
- 

## Performance Impact

- [x] No performance impact
- [ ] Positive performance impact
- [ ] Negative performance impact (explain below)
- [ ] Performance impact unknown

Details:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots/Videos (if applicable)

Add screenshots or videos demonstrating the changes:

## Additional Notes

Any additional information, context, or notes for reviewers:

---

### For Maintainers

- [ ] Code review completed
- [ ] Tests pass
- [ ] Ready to merge
