### PR TITLE
feat(CCSGameRules): GoToIntermission

### DIFF
--- a/managed/src/SwiftlyS2.Core/Modules/Schemas/Extensions/CCSGameRules.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/Schemas/Extensions/CCSGameRules.cs
@@ -30,6 +30,12 @@ public partial interface CCSGameRules
     /// <param name="teamId">The team id to end the round for</param>
     /// <param name="unk01">Unknown parameter</param>
     public void TerminateRound( RoundEndReason reason, float delay, uint teamId, uint unk01 = 0 );
+    
+    /// <summary>
+    /// Go to the intermission phase of the game.
+    /// </summary>
+    /// <param name="bAbortedMatch">Indicates whether the match was aborted</param>
+    public void GoToIntermission(bool bAbortedMatch = false);
 
     /// <summary>
     /// 

--- a/managed/src/SwiftlyS2.Core/Modules/Schemas/Extensions/CCSGameRulesImpl.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/Schemas/Extensions/CCSGameRulesImpl.cs
@@ -30,6 +30,11 @@ internal partial class CCSGameRulesImpl : CCSGameRules
     {
         GameFunctions.TerminateRound(Address, (uint)reason, delay, teamId);
     }
+    
+    public void GoToIntermission(bool bAbortedMatch)
+    {
+        GameFunctions.GoToIntermission(Address, bAbortedMatch);
+    }
 
     public ref CViewVectors GetViewVectors()
     {

--- a/managed/src/SwiftlyS2.Core/Natives/GameFunctions.cs
+++ b/managed/src/SwiftlyS2.Core/Natives/GameFunctions.cs
@@ -41,6 +41,7 @@ internal static class GameFunctions
     private static readonly Lazy<int> _collisionRulesChangedOffset = CreateOffset("CBaseEntity::CollisionRulesChanged");
     private static readonly Lazy<int> _respawnOffset = CreateOffset("CCSPlayerController::Respawn");
     private static readonly Lazy<int> _getViewVectorsOffset = CreateOffset("CGameRules::GetViewVectors");
+    private static readonly Lazy<int> _goToIntermissionOffset = CreateOffset("CGameRules::GoToIntermission");
 
     public static int TeleportOffset => _teleportOffset.Value;
     public static int CommitSuicideOffset => _commitSuicideOffset.Value;
@@ -55,6 +56,7 @@ internal static class GameFunctions
     public static int CollisionRulesChangedOffset => _collisionRulesChangedOffset.Value;
     public static int RespawnOffset => _respawnOffset.Value;
     public static int GetViewVectorsOffset => _getViewVectorsOffset.Value;
+    public static int GoToIntermissionOffset => _goToIntermissionOffset.Value;
 
     private static void CheckPtr( nint ptr, string name )
     {
@@ -132,6 +134,23 @@ internal static class GameFunctions
                 {
                     pTerminateRoundLinux(gameRules, reason, teamId > 0 ? (nint)(&teamId) : 0, delay);
                 }
+            }
+        }
+        catch (Exception e)
+        {
+            AnsiConsole.WriteException(e);
+        }
+    }
+    
+    public static void GoToIntermission( nint gameRules, bool bAbortedMatch )
+    {
+        try
+        {
+            CheckPtr(gameRules, nameof(gameRules));
+            unsafe
+            {
+                var pGoToIntermission = (delegate* unmanaged< nint, byte, void >)GetVirtualFunction(gameRules, GoToIntermissionOffset);
+                pGoToIntermission(gameRules, (byte)(bAbortedMatch ? 1 : 0));
             }
         }
         catch (Exception e)

--- a/managed/src/TestPlugin/TestPlugin.cs
+++ b/managed/src/TestPlugin/TestPlugin.cs
@@ -739,6 +739,12 @@ public class TestPlugin : BasePlugin
         Core.EntitySystem.GetGameRules()!.TerminateRound(RoundEndReason.BombDefused, 10.0f);
     }
 
+    [Command("intermission")]
+    public void TestIntermissionCommand( ICommandContext context )
+    {
+        Core.EntitySystem.GetGameRules()!.GoToIntermission();
+    }
+
     [Command("tt8")]
     public unsafe void TestCommand8( ICommandContext context )
     {

--- a/plugin_files/gamedata/cs2/core/offsets.jsonc
+++ b/plugin_files/gamedata/cs2/core/offsets.jsonc
@@ -61,6 +61,10 @@
         "windows": 25,
         "linux": 26
     },
+    "CGameRules::GoToIntermission": {
+        "windows": 128,
+        "linux": 129
+    },
     "CCSPlayer_ItemServices::DropActiveItem": {
         "windows": 22,
         "linux": 23


### PR DESCRIPTION
## Description

Add `GoToIntermission` Virtual call to `CCSGameRules`

Actually, in theory, there’s no need to include this in `managed`, but since `managed` already has `TerminateRound`, I thought why not add `GoToIntermission` as well? So I created this pr.

## Type of Change

- [X] New feature (non-breaking change which adds functionality)

## Related Issues

None

## Changes Made

- [X] Managed Changes (C#)

### Detailed Changes

List the specific changes made:

- Add a function call to GameFunctions and CCSGameRules

## Testing

### Test Environment

- **OS**: Windows 11
- **Game**: Counter-Strike 2

### Test Cases

Describe the test cases you've run:

1. sw_intermission

## Breaking Changes

None

## Performance Impact

- [X] No performance impact
- [ ] Positive performance impact
- [ ] Negative performance impact (explain below)
- [ ] Performance impact unknown

Details:

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Screenshots/Videos (if applicable)

Add screenshots or videos demonstrating the changes:

## Additional Notes

Any additional information, context, or notes for reviewers:

---

### For Maintainers

- [ ] Code review completed
- [ ] Tests pass
- [ ] Ready to merge
