### PR TITLE
fix(managed): handle null TakeDamageResult

### DIFF
--- a/managed/src/SwiftlyS2.Core/Modules/Events/EventPublisher.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/Events/EventPublisher.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using Spectre.Console;
 using SwiftlyS2.Shared.Misc;
+using SwiftlyS2.Shared.Natives;
 using SwiftlyS2.Core.Natives;
 using SwiftlyS2.Shared.Events;
 using SwiftlyS2.Core.Scheduler;
@@ -637,6 +638,21 @@ internal static class EventPublisher
         {
             unsafe
             {
+                var newTakeDamageResult = new CTakeDamageResult();
+                if (takeDamageResultPtr == 0 && takeDamageInfoPtr != 0)
+                {
+                    var damageInfo = (CTakeDamageInfo*)takeDamageInfoPtr;
+                    newTakeDamageResult.OriginatingInfo = damageInfo;
+                    newTakeDamageResult.HealthLost = (int)damageInfo->Damage;
+                    newTakeDamageResult.DamageDealt = damageInfo->Damage;
+                    newTakeDamageResult.PreModifiedDamage = damageInfo->Damage;
+                    newTakeDamageResult.TotalledDamageDealt = damageInfo->Damage;
+                    newTakeDamageResult.TotalledHealthLost = (int)damageInfo->Damage;
+                    newTakeDamageResult.TotalledPreModifiedDamage = damageInfo->Damage;
+                    newTakeDamageResult.DamageFlags = damageInfo->DamageFlags;
+                    takeDamageResultPtr = (nint)(&newTakeDamageResult);
+                }
+
                 OnEntityTakeDamageEvent @event = new() {
                     Entity = EntityManager.GetEntityByAddress(entityPtr) ?? new CEntityInstanceImpl(entityPtr),
                     _infoPtr = takeDamageInfoPtr,

--- a/managed/src/SwiftlyS2.Core/Modules/Events/EventPublisher.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/Events/EventPublisher.cs
@@ -638,9 +638,9 @@ internal static class EventPublisher
         {
             unsafe
             {
-                var newTakeDamageResult = new CTakeDamageResult();
                 if (takeDamageResultPtr == 0 && takeDamageInfoPtr != 0)
                 {
+                    var newTakeDamageResult = new CTakeDamageResult();
                     var damageInfo = (CTakeDamageInfo*)takeDamageInfoPtr;
                     newTakeDamageResult.OriginatingInfo = damageInfo;
                     newTakeDamageResult.HealthLost = (int)damageInfo->Damage;

--- a/managed/src/TestPlugin/TestPlugin.cs
+++ b/managed/src/TestPlugin/TestPlugin.cs
@@ -480,6 +480,7 @@ public class TestPlugin : BasePlugin
         // Core.Event.OnEntityTakeDamage += ( @event ) =>
         // {
         //     Console.WriteLine(@event.Entity.DesignerName);
+        //     Console.WriteLine($"OnEntityTakeDamage>> DamageResult.DamageDealt[{@event.DamageResult.DamageDealt}]");
         //     @event.Info.DamageFlags = TakeDamageFlags_t.DFLAG_SUPPRESS_BREAKABLES;
         //     @event.Result = HookResult.Stop;
         // };


### PR DESCRIPTION
## Description
I’m not sure if I fixed it in the most appropriate place.
Accessing `@event.DamageResult` in `OnEntityTakeDamage` results in a null pointer exception. When the incoming `CTakeDamageResult` is null, `TakeDamage` creates one internally, but it’s not accessible when hooking in Pre.
https://discord.com/channels/1419042580980699159/1421117496169074719/1446977205673394196

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] Build/CI improvement

## Related Issues

Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)

## Changes Made

- [ ] Native changes (C++)
- [x] Managed Changes (C#)
- [ ] API additions/modifications
- [ ] Memory management improvements
- [ ] Network handling changes
- [ ] SDK updates
- [ ] Build system changes

### Detailed Changes

List the specific changes made:

- 
- 
- 

## Testing

### Test Environment

- **OS**: Windows 11
- **Game**: Counter-Strike 2

### Test Cases

Describe the test cases you've run:

1. 
2. 
3. 

## Breaking Changes

List any breaking changes and migration steps:

- 
- 

## Performance Impact

- [ ] No performance impact
- [ ] Positive performance impact
- [ ] Negative performance impact (explain below)
- [x] Performance impact unknown

Details:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots/Videos (if applicable)

Add screenshots or videos demonstrating the changes:

## Additional Notes

Any additional information, context, or notes for reviewers:

---

### For Maintainers

- [ ] Code review completed
- [ ] Tests pass
- [ ] Ready to merge
