### PR TITLE
feat: ConVar/Command enumeration, entity schema walker, and raw net message hooks

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -194,3 +194,23 @@ Credits to @ipsvn for the `bf_write` fix and StringTable serialization method fo
 Related links:
 - https://github.com/alliedmodders/hl2sdk/pull/364
 - https://github.com/ipsvn/ReplicateStringTableValue
+
+## CS2ServerGUI
+
+Raw (untyped) net message hooks (`HookClientMessageRaw` / `HookServerMessageRaw`) and the
+`bf_read`-based parsing of `CCLCMsg_Move.data` via `CSGOUserCmdPB` were inspired by the
+`FilterMessage` / `SendNetMessage` vtable hook architecture in
+[Source2ZE/CS2ServerGUI](https://github.com/Source2ZE/CS2ServerGUI) by Poggu.
+
+```
+/**
+ * =============================================================================
+ * CS2ServerGUI
+ * Copyright (C) 2024 Poggu
+ * =============================================================================
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 3.0, as published by the
+ * Free Software Foundation.
+ */
+```

--- a/managed/src/SwiftlyS2.Core/Modules/Convars/ConVarService.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/Convars/ConVarService.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using SwiftlyS2.Core.Natives;
 using SwiftlyS2.Shared.Convars;
 using SwiftlyS2.Shared.Natives;
@@ -5,6 +6,24 @@ using SwiftlyS2.Shared.NetMessages;
 using SwiftlyS2.Shared.ProtobufDefinitions;
 
 namespace SwiftlyS2.Core.Convars;
+
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+internal unsafe struct ConVarFlatInfo
+{
+    public fixed byte _name[128];
+    public fixed byte _type[16];
+    public fixed byte _defaultValue[256];
+    public fixed byte _description[512];
+    public ulong _flags;
+}
+
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+internal unsafe struct ConCommandFlatInfo
+{
+    public fixed byte _name[128];
+    public fixed byte _description[512];
+    public ulong _flags;
+}
 
 internal enum EConVarType : int
 {
@@ -301,18 +320,52 @@ internal class ConVarService : IConVarService
         });
     }
 
-    public string EnumerateAllConVars()
+    private static unsafe string ReadFlatStr(byte* ptr) => Marshal.PtrToStringUTF8((nint)ptr) ?? string.Empty;
+
+    public unsafe IReadOnlyList<ConVarInfo> EnumerateAllConVars()
     {
-        try { return NativeConvars.EnumerateAll(); }
-        catch (NullReferenceException) { return "[]"; }
-        catch (AccessViolationException) { return "[]"; }
+        var (ptr, count) = NativeConvars.EnumerateAll();
+        if (count == 0) return [];
+        try
+        {
+            var result = new ConVarInfo[count];
+            var flat = (ConVarFlatInfo*)ptr;
+            for (int i = 0; i < count; i++)
+            {
+                result[i] = new ConVarInfo
+                {
+                    Name = ReadFlatStr(flat[i]._name),
+                    Type = ReadFlatStr(flat[i]._type),
+                    Default = ReadFlatStr(flat[i]._defaultValue),
+                    Description = ReadFlatStr(flat[i]._description),
+                    Flags = flat[i]._flags
+                };
+            }
+            return result;
+        }
+        finally { NativeAllocator.Free(ptr); }
     }
 
-    public string EnumerateAllCommands()
+    public unsafe IReadOnlyList<ConCommandInfo> EnumerateAllCommands()
     {
-        try { return NativeCommands.EnumerateAll(); }
-        catch (NullReferenceException) { return "[]"; }
-        catch (AccessViolationException) { return "[]"; }
+        var (ptr, count) = NativeCommands.EnumerateAll();
+        if (count == 0) return [];
+        try
+        {
+            var result = new ConCommandInfo[count];
+            var flat = (ConCommandFlatInfo*)ptr;
+            for (int i = 0; i < count; i++)
+            {
+                result[i] = new ConCommandInfo
+                {
+                    Name = ReadFlatStr(flat[i]._name),
+                    Description = ReadFlatStr(flat[i]._description),
+                    Flags = flat[i]._flags
+                };
+            }
+            return result;
+        }
+        finally { NativeAllocator.Free(ptr); }
     }
 
     public int UnlockAllConVars(ConvarFlags flagsToRemove = ConvarFlags.HIDDEN | ConvarFlags.DEVELOPMENT_ONLY | ConvarFlags.CLIENTDLL | ConvarFlags.DEFENSIVE)

--- a/managed/src/SwiftlyS2.Core/Modules/Convars/ConVarService.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/Convars/ConVarService.cs
@@ -336,7 +336,7 @@ internal class ConVarService : IConVarService
                 {
                     Name = ReadFlatStr(flat[i]._name),
                     Type = ReadFlatStr(flat[i]._type),
-                    Default = ReadFlatStr(flat[i]._defaultValue),
+                    DefaultValue = ReadFlatStr(flat[i]._defaultValue),
                     Description = ReadFlatStr(flat[i]._description),
                     Flags = flat[i]._flags
                 };

--- a/managed/src/SwiftlyS2.Core/Modules/Convars/ConVarService.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/Convars/ConVarService.cs
@@ -300,4 +300,32 @@ internal class ConVarService : IConVarService
             msg.Recipients.AddAllPlayers();
         });
     }
+
+    public string EnumerateAllConVars()
+    {
+        try { return NativeConvars.EnumerateAll(); }
+        catch (NullReferenceException) { return "[]"; }
+        catch (AccessViolationException) { return "[]"; }
+    }
+
+    public string EnumerateAllCommands()
+    {
+        try { return NativeCommands.EnumerateAll(); }
+        catch (NullReferenceException) { return "[]"; }
+        catch (AccessViolationException) { return "[]"; }
+    }
+
+    public int UnlockAllConVars(ConvarFlags flagsToRemove = ConvarFlags.HIDDEN | ConvarFlags.DEVELOPMENT_ONLY | ConvarFlags.CLIENTDLL | ConvarFlags.DEFENSIVE)
+    {
+        try { return NativeConvars.UnlockAll((ulong)flagsToRemove); }
+        catch (NullReferenceException) { return 0; }
+        catch (AccessViolationException) { return 0; }
+    }
+
+    public int UnlockAllCommands(ConvarFlags flagsToRemove = ConvarFlags.HIDDEN | ConvarFlags.DEVELOPMENT_ONLY | ConvarFlags.CLIENTDLL | ConvarFlags.DEFENSIVE)
+    {
+        try { return NativeCommands.UnlockAll((ulong)flagsToRemove); }
+        catch (NullReferenceException) { return 0; }
+        catch (AccessViolationException) { return 0; }
+    }
 }

--- a/managed/src/SwiftlyS2.Core/Modules/Memory/MemoryService.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/Memory/MemoryService.cs
@@ -206,12 +206,15 @@ internal class MemoryService : IMemoryService, IDisposable
             if (parts.Length < 5) continue;
 
             var depth = int.Parse(parts[0]);
+            var children = new List<EntityFieldInfo>();
             var field = new EntityFieldInfo
             {
                 Name = parts[1],
                 Type = parts[2],
                 Offset = int.Parse(parts[3]),
-                Value = string.Join("\t", parts.Skip(4))
+                Value = string.Join("\t", parts.Skip(4)),
+                Depth = depth,
+                Children = children
             };
 
             while (stack.Count > depth)
@@ -221,8 +224,8 @@ internal class MemoryService : IMemoryService, IDisposable
             target.Add(field);
 
             while (stack.Count <= depth)
-                stack.Add(field.Children);
-            stack[depth] = field.Children;
+                stack.Add(children);
+            stack[depth] = children;
         }
 
         return root;

--- a/managed/src/SwiftlyS2.Core/Modules/Memory/MemoryService.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/Memory/MemoryService.cs
@@ -190,4 +190,9 @@ internal class MemoryService : IMemoryService, IDisposable
         serverSideClient.SetDangerousHandle(address);
         return serverSideClient;
     }
+
+    public string GetEntityFields( nint entity, string className )
+    {
+        return NativeSchema.GetEntityFields( entity, className );
+    }
 }

--- a/managed/src/SwiftlyS2.Core/Modules/Memory/MemoryService.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/Memory/MemoryService.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using SwiftlyS2.Core.Hooks;
 using SwiftlyS2.Core.Natives;
 using SwiftlyS2.Core.Extensions;
+using SwiftlyS2.Core.ProtobufDefinitions;
 using SwiftlyS2.Shared.Memory;
 using SwiftlyS2.Shared.Schemas;
 using SwiftlyS2.Shared.Engine;
@@ -194,5 +195,15 @@ internal class MemoryService : IMemoryService, IDisposable
     public string GetEntityFields( nint entity, string className )
     {
         return NativeSchema.GetEntityFields( entity, className );
+    }
+
+    public string DebugProtobuf( nint protoMsgPtr )
+    {
+        return NativeNetMessages.DebugString( protoMsgPtr );
+    }
+
+    public string FormatMoveDetail( nint moveMsgPtr )
+    {
+        return NativeNetMessages.FormatMoveDebugString( moveMsgPtr );
     }
 }

--- a/managed/src/SwiftlyS2.Core/Modules/Memory/MemoryService.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/Memory/MemoryService.cs
@@ -192,9 +192,40 @@ internal class MemoryService : IMemoryService, IDisposable
         return serverSideClient;
     }
 
-    public string GetEntityFields( nint entity, string className )
+    public IReadOnlyList<EntityFieldInfo> GetEntityFields( nint entity, string className )
     {
-        return NativeSchema.GetEntityFields( entity, className );
+        var raw = NativeSchema.GetEntityFields( entity, className );
+        if (string.IsNullOrEmpty(raw)) return [];
+
+        var root = new List<EntityFieldInfo>();
+        var stack = new List<List<EntityFieldInfo>>();
+
+        foreach (var line in raw.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parts = line.Split('\t');
+            if (parts.Length < 5) continue;
+
+            var depth = int.Parse(parts[0]);
+            var field = new EntityFieldInfo
+            {
+                Name = parts[1],
+                Type = parts[2],
+                Offset = int.Parse(parts[3]),
+                Value = string.Join("\t", parts.Skip(4))
+            };
+
+            while (stack.Count > depth)
+                stack.RemoveAt(stack.Count - 1);
+
+            var target = depth == 0 ? root : stack[depth - 1];
+            target.Add(field);
+
+            while (stack.Count <= depth)
+                stack.Add(field.Children);
+            stack[depth] = field.Children;
+        }
+
+        return root;
     }
 
     public string DebugProtobuf( nint protoMsgPtr )

--- a/managed/src/SwiftlyS2.Core/Modules/NetMessages/NetMessage.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/NetMessages/NetMessage.cs
@@ -6,6 +6,23 @@ using SwiftlyS2.Shared.NetMessages;
 
 namespace SwiftlyS2.Core.NetMessages;
 
+internal static class NetMessageOffsets
+{
+    /*
+     
+    Evil hack to convert a CNetMessagePB<>* to google::protobuf::Message*
+    
+    CNetMessage memory layout:
+    vtable -> 8 bytes
+    members -> 40 bytes
+    
+    and CNetMessagePB inheritance: public CNetMessage, public PROTO_TYPE
+    so we can cast to PROTO_TYPE* by adding 48 bytes to the handle
+    
+    */
+    public const int CNetMessageToProtobuf = 48;
+}
+
 internal class NetMessage<T> : TypedProtobuf<T>, INativeHandle, IDisposable
     where T : ITypedProtobuf<T>, INetMessage<T>, IDisposable
 {
@@ -17,19 +34,7 @@ internal class NetMessage<T> : TypedProtobuf<T>, INativeHandle, IDisposable
         get => ref _filter;
     }
 
-    /*
-
-    Evil hack to convert a CNetMessagePB<>* to google::protobuf::Message*
-
-    CNetMessage memory layout:
-    vtable -> 8 bytes
-    members -> 40 bytes
-
-    and CNetMessagePB inheritance: public CNetMessage, public PROTO_TYPE
-    so we can cast to PROTO_TYPE* by adding 48 bytes to the handle
-
-    */
-    public NetMessage( nint handle, bool isManuallyAllocated ) : base(handle + 48)
+    public NetMessage( nint handle, bool isManuallyAllocated ) : base(handle + NetMessageOffsets.CNetMessageToProtobuf)
     {
         if (isManuallyAllocated)
         {

--- a/managed/src/SwiftlyS2.Core/Modules/NetMessages/NetMessageHookCallback.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/NetMessages/NetMessageHookCallback.cs
@@ -179,3 +179,135 @@ internal class NetMessageServerInternalHookCallback<T> : NetMessageHookCallback 
     }
 
 }
+
+// ── Raw (untyped) hooks – catch ALL messages ──────────────────────
+
+internal class NetMessageClientRawHookCallback : NetMessageHookCallback
+{
+
+    private INetMessageService.RawClientNetMessageHandler _callback;
+    private NetMessageClientHookCallbackDelegate _unmanagedCallback;
+    private nint _unmanagedCallbackPtr;
+    private ulong _nativeListenerId;
+    private ILogger<NetMessageClientRawHookCallback> _logger;
+    private readonly int _cnetMsgSize;
+
+    public NetMessageClientRawHookCallback( INetMessageService.RawClientNetMessageHandler callback, ILoggerFactory loggerFactory, IContextedProfilerService profiler ) : base(loggerFactory, profiler)
+    {
+        Guid = Guid.NewGuid();
+        _logger = LoggerFactory.CreateLogger<NetMessageClientRawHookCallback>();
+        _cnetMsgSize = NativeNetMessages.GetCNetMessageSize();
+
+        _callback = callback;
+
+        _unmanagedCallback = ( playerId, msgId, pMessage ) =>
+        {
+            try
+            {
+                // pMessage is CNetMessage*; shift by sizeof(CNetMessage) to get google::protobuf::Message*
+                var result = _callback(playerId, msgId, pMessage + _cnetMsgSize);
+                return result;
+            }
+            catch (Exception e)
+            {
+                if (!GlobalExceptionHandler.Handle(ref e)) return HookResult.Continue;
+                _logger.LogError(e, "Error in raw client net message hook callback (msgId={MsgId})", msgId);
+                return HookResult.Continue;
+            }
+        };
+        _unmanagedCallbackPtr = Marshal.GetFunctionPointerForDelegate(_unmanagedCallback);
+        _nativeListenerId = NativeNetMessages.AddNetMessageClientHook(_unmanagedCallbackPtr);
+    }
+
+    public override void Dispose()
+    {
+        NativeNetMessages.RemoveNetMessageClientHook(_nativeListenerId);
+    }
+
+}
+
+internal class NetMessageServerRawHookCallback : NetMessageHookCallback
+{
+
+    private INetMessageService.RawServerNetMessageHandler _callback;
+    private NetMessageServerHookCallbackDelegate _unmanagedCallback;
+    private nint _unmanagedCallbackPtr;
+    private ulong _nativeListenerId;
+    private ILogger<NetMessageServerRawHookCallback> _logger;
+    private readonly int _cnetMsgSize;
+
+    public NetMessageServerRawHookCallback( INetMessageService.RawServerNetMessageHandler callback, ILoggerFactory loggerFactory, IContextedProfilerService profiler ) : base(loggerFactory, profiler)
+    {
+        Guid = Guid.NewGuid();
+        _logger = LoggerFactory.CreateLogger<NetMessageServerRawHookCallback>();
+        _cnetMsgSize = NativeNetMessages.GetCNetMessageSize();
+
+        _callback = callback;
+
+        _unmanagedCallback = ( pPlayerMask, msgId, pMessage ) =>
+        {
+            try
+            {
+                var result = _callback(pPlayerMask, msgId, pMessage + _cnetMsgSize);
+                return result;
+            }
+            catch (Exception e)
+            {
+                if (!GlobalExceptionHandler.Handle(ref e)) return HookResult.Continue;
+                _logger.LogError(e, "Error in raw server net message hook callback (msgId={MsgId})", msgId);
+                return HookResult.Continue;
+            }
+        };
+        _unmanagedCallbackPtr = Marshal.GetFunctionPointerForDelegate(_unmanagedCallback);
+        _nativeListenerId = NativeNetMessages.AddNetMessageServerHook(_unmanagedCallbackPtr);
+    }
+
+    public override void Dispose()
+    {
+        NativeNetMessages.RemoveNetMessageServerHook(_nativeListenerId);
+    }
+
+}
+
+internal class NetMessageServerInternalRawHookCallback : NetMessageHookCallback
+{
+
+    private INetMessageService.RawServerNetMessageInternalHandler _callback;
+    private NetMessageClientHookCallbackDelegate _unmanagedCallback;
+    private nint _unmanagedCallbackPtr;
+    private ulong _nativeListenerId;
+    private ILogger<NetMessageServerInternalRawHookCallback> _logger;
+    private readonly int _cnetMsgSize;
+
+    public NetMessageServerInternalRawHookCallback( INetMessageService.RawServerNetMessageInternalHandler callback, ILoggerFactory loggerFactory, IContextedProfilerService profiler ) : base(loggerFactory, profiler)
+    {
+        Guid = Guid.NewGuid();
+        _logger = LoggerFactory.CreateLogger<NetMessageServerInternalRawHookCallback>();
+        _cnetMsgSize = NativeNetMessages.GetCNetMessageSize();
+
+        _callback = callback;
+
+        _unmanagedCallback = ( playerId, msgId, pMessage ) =>
+        {
+            try
+            {
+                var result = _callback(playerId, msgId, pMessage + _cnetMsgSize);
+                return result;
+            }
+            catch (Exception e)
+            {
+                if (!GlobalExceptionHandler.Handle(ref e)) return HookResult.Continue;
+                _logger.LogError(e, "Error in raw server net internal hook callback (msgId={MsgId})", msgId);
+                return HookResult.Continue;
+            }
+        };
+        _unmanagedCallbackPtr = Marshal.GetFunctionPointerForDelegate(_unmanagedCallback);
+        _nativeListenerId = NativeNetMessages.AddNetMessageServerHookInternal(_unmanagedCallbackPtr);
+    }
+
+    public override void Dispose()
+    {
+        NativeNetMessages.RemoveNetMessageServerHookInternal(_nativeListenerId);
+    }
+
+}

--- a/managed/src/SwiftlyS2.Core/Modules/NetMessages/NetMessageHookCallback.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/NetMessages/NetMessageHookCallback.cs
@@ -180,6 +180,26 @@ internal class NetMessageServerInternalHookCallback<T> : NetMessageHookCallback 
 
 }
 
+internal sealed class UntypedNetMessage : IUntypedNetMessage
+{
+    private readonly IProtobufAccessor _accessor;
+    private readonly int _msgId;
+
+    public int MessageId => _msgId;
+
+    public string MessageName => NativeNetMessages.GetMessageNameById(_msgId);
+
+    public IProtobufAccessor Accessor => _accessor;
+
+    public string GetDebugString() => NativeNetMessages.DebugString(_accessor.Address);
+
+    internal UntypedNetMessage(nint protoPtr, int msgId)
+    {
+        _accessor = new ProtobufAccessor(protoPtr);
+        _msgId = msgId;
+    }
+}
+
 // ── Raw (untyped) hooks – catch ALL messages ──────────────────────
 
 internal class NetMessageClientRawHookCallback : NetMessageHookCallback
@@ -190,13 +210,12 @@ internal class NetMessageClientRawHookCallback : NetMessageHookCallback
     private nint _unmanagedCallbackPtr;
     private ulong _nativeListenerId;
     private ILogger<NetMessageClientRawHookCallback> _logger;
-    private readonly int _cnetMsgSize;
+    private static readonly int CNetMsgOffset = NativeNetMessages.GetCNetMessageSize();
 
     public NetMessageClientRawHookCallback( INetMessageService.RawClientNetMessageHandler callback, ILoggerFactory loggerFactory, IContextedProfilerService profiler ) : base(loggerFactory, profiler)
     {
         Guid = Guid.NewGuid();
         _logger = LoggerFactory.CreateLogger<NetMessageClientRawHookCallback>();
-        _cnetMsgSize = NativeNetMessages.GetCNetMessageSize();
 
         _callback = callback;
 
@@ -204,8 +223,8 @@ internal class NetMessageClientRawHookCallback : NetMessageHookCallback
         {
             try
             {
-                // pMessage is CNetMessage*; shift by sizeof(CNetMessage) to get google::protobuf::Message*
-                var result = _callback(playerId, msgId, pMessage + _cnetMsgSize);
+                var msg = new UntypedNetMessage(pMessage + CNetMsgOffset, msgId);
+                var result = _callback(playerId, msg);
                 return result;
             }
             catch (Exception e)
@@ -234,13 +253,12 @@ internal class NetMessageServerRawHookCallback : NetMessageHookCallback
     private nint _unmanagedCallbackPtr;
     private ulong _nativeListenerId;
     private ILogger<NetMessageServerRawHookCallback> _logger;
-    private readonly int _cnetMsgSize;
+    private static readonly int CNetMsgOffset = NativeNetMessages.GetCNetMessageSize();
 
     public NetMessageServerRawHookCallback( INetMessageService.RawServerNetMessageHandler callback, ILoggerFactory loggerFactory, IContextedProfilerService profiler ) : base(loggerFactory, profiler)
     {
         Guid = Guid.NewGuid();
         _logger = LoggerFactory.CreateLogger<NetMessageServerRawHookCallback>();
-        _cnetMsgSize = NativeNetMessages.GetCNetMessageSize();
 
         _callback = callback;
 
@@ -248,7 +266,8 @@ internal class NetMessageServerRawHookCallback : NetMessageHookCallback
         {
             try
             {
-                var result = _callback(pPlayerMask, msgId, pMessage + _cnetMsgSize);
+                var msg = new UntypedNetMessage(pMessage + CNetMsgOffset, msgId);
+                var result = _callback(msg, pPlayerMask);
                 return result;
             }
             catch (Exception e)
@@ -277,13 +296,12 @@ internal class NetMessageServerInternalRawHookCallback : NetMessageHookCallback
     private nint _unmanagedCallbackPtr;
     private ulong _nativeListenerId;
     private ILogger<NetMessageServerInternalRawHookCallback> _logger;
-    private readonly int _cnetMsgSize;
+    private static readonly int CNetMsgOffset = NativeNetMessages.GetCNetMessageSize();
 
     public NetMessageServerInternalRawHookCallback( INetMessageService.RawServerNetMessageInternalHandler callback, ILoggerFactory loggerFactory, IContextedProfilerService profiler ) : base(loggerFactory, profiler)
     {
         Guid = Guid.NewGuid();
         _logger = LoggerFactory.CreateLogger<NetMessageServerInternalRawHookCallback>();
-        _cnetMsgSize = NativeNetMessages.GetCNetMessageSize();
 
         _callback = callback;
 
@@ -291,7 +309,8 @@ internal class NetMessageServerInternalRawHookCallback : NetMessageHookCallback
         {
             try
             {
-                var result = _callback(playerId, msgId, pMessage + _cnetMsgSize);
+                var msg = new UntypedNetMessage(pMessage + CNetMsgOffset, msgId);
+                var result = _callback(playerId, msg);
                 return result;
             }
             catch (Exception e)

--- a/managed/src/SwiftlyS2.Core/Modules/NetMessages/NetMessageService.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/NetMessages/NetMessageService.cs
@@ -51,6 +51,41 @@ internal class NetMessageService : INetMessageService, IDisposable
         return hook.Guid;
     }
 
+    public string GetMessageNameById( int msgId )
+    {
+        return NativeNetMessages.GetMessageNameById(msgId);
+    }
+
+    public Guid HookClientMessageRaw( INetMessageService.RawClientNetMessageHandler callback )
+    {
+        var hook = new NetMessageClientRawHookCallback(callback, _loggerFactory, _profiler);
+        lock (_lock)
+        {
+            _callbacks.Add(hook);
+        }
+        return hook.Guid;
+    }
+
+    public Guid HookServerMessageRaw( INetMessageService.RawServerNetMessageHandler callback )
+    {
+        var hook = new NetMessageServerRawHookCallback(callback, _loggerFactory, _profiler);
+        lock (_lock)
+        {
+            _callbacks.Add(hook);
+        }
+        return hook.Guid;
+    }
+
+    public Guid HookServerMessageInternalRaw( INetMessageService.RawServerNetMessageInternalHandler callback )
+    {
+        var hook = new NetMessageServerInternalRawHookCallback(callback, _loggerFactory, _profiler);
+        lock (_lock)
+        {
+            _callbacks.Add(hook);
+        }
+        return hook.Guid;
+    }
+
     public void Unhook( Guid guid )
     {
         lock (_lock)

--- a/managed/src/SwiftlyS2.Core/Modules/NetMessages/NetMessageService.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/NetMessages/NetMessageService.cs
@@ -150,6 +150,54 @@ internal class NetMessageService : INetMessageService, IDisposable
         }
     }
 
+    public void UnhookClientMessageRaw()
+    {
+        lock (_lock)
+        {
+            _ = _callbacks.RemoveAll(callback =>
+            {
+                if (callback is NetMessageClientRawHookCallback raw)
+                {
+                    raw.Dispose();
+                    return true;
+                }
+                return false;
+            });
+        }
+    }
+
+    public void UnhookServerMessageRaw()
+    {
+        lock (_lock)
+        {
+            _ = _callbacks.RemoveAll(callback =>
+            {
+                if (callback is NetMessageServerRawHookCallback raw)
+                {
+                    raw.Dispose();
+                    return true;
+                }
+                return false;
+            });
+        }
+    }
+
+    public void UnhookServerMessageInternalRaw()
+    {
+        lock (_lock)
+        {
+            _ = _callbacks.RemoveAll(callback =>
+            {
+                if (callback is NetMessageServerInternalRawHookCallback raw)
+                {
+                    raw.Dispose();
+                    return true;
+                }
+                return false;
+            });
+        }
+    }
+
     private nint AllocateNetMessage( int msgId )
     {
         var handle = NativeNetMessages.AllocateNetMessageByID(msgId);

--- a/managed/src/SwiftlyS2.Generated/Natives/Commands.cs
+++ b/managed/src/SwiftlyS2.Generated/Natives/Commands.cs
@@ -123,4 +123,23 @@ internal static class NativeCommands
     {
         _UnregisterClientChatListener(callbackID);
     }
+
+    private unsafe static delegate* unmanaged<int*, byte*> _EnumerateAll;
+
+    public unsafe static string EnumerateAll()
+    {
+        var length = 0;
+        var returnedPtr = _EnumerateAll(&length);
+        var outString = StringAlloc.CreateCSharpString((nint)returnedPtr, length);
+        NativeAllocator.Free((nint)returnedPtr);
+        return outString;
+    }
+
+    private unsafe static delegate* unmanaged<ulong, int> _UnlockAll;
+
+    public unsafe static int UnlockAll(ulong flagsToRemove)
+    {
+        var ret = _UnlockAll(flagsToRemove);
+        return ret;
+    }
 }

--- a/managed/src/SwiftlyS2.Generated/Natives/Commands.cs
+++ b/managed/src/SwiftlyS2.Generated/Natives/Commands.cs
@@ -124,15 +124,13 @@ internal static class NativeCommands
         _UnregisterClientChatListener(callbackID);
     }
 
-    private unsafe static delegate* unmanaged<int*, byte*> _EnumerateAll;
+    private unsafe static delegate* unmanaged<int*, nint> _EnumerateAll;
 
-    public unsafe static string EnumerateAll()
+    public unsafe static (nint ptr, int count) EnumerateAll()
     {
-        var length = 0;
-        var returnedPtr = _EnumerateAll(&length);
-        var outString = StringAlloc.CreateCSharpString((nint)returnedPtr, length);
-        NativeAllocator.Free((nint)returnedPtr);
-        return outString;
+        var count = 0;
+        var ptr = _EnumerateAll(&count);
+        return (ptr, count);
     }
 
     private unsafe static delegate* unmanaged<ulong, int> _UnlockAll;

--- a/managed/src/SwiftlyS2.Generated/Natives/Convars.cs
+++ b/managed/src/SwiftlyS2.Generated/Natives/Convars.cs
@@ -588,4 +588,23 @@ internal static class NativeConvars
             return outString;
         });
     }
+
+    private unsafe static delegate* unmanaged<int*, byte*> _EnumerateAll;
+
+    public unsafe static string EnumerateAll()
+    {
+        var length = 0;
+        var returnedPtr = _EnumerateAll(&length);
+        var outString = StringAlloc.CreateCSharpString((nint)returnedPtr, length);
+        NativeAllocator.Free((nint)returnedPtr);
+        return outString;
+    }
+
+    private unsafe static delegate* unmanaged<ulong, int> _UnlockAll;
+
+    public unsafe static int UnlockAll(ulong flagsToRemove)
+    {
+        var ret = _UnlockAll(flagsToRemove);
+        return ret;
+    }
 }

--- a/managed/src/SwiftlyS2.Generated/Natives/Convars.cs
+++ b/managed/src/SwiftlyS2.Generated/Natives/Convars.cs
@@ -589,15 +589,13 @@ internal static class NativeConvars
         });
     }
 
-    private unsafe static delegate* unmanaged<int*, byte*> _EnumerateAll;
+    private unsafe static delegate* unmanaged<int*, nint> _EnumerateAll;
 
-    public unsafe static string EnumerateAll()
+    public unsafe static (nint ptr, int count) EnumerateAll()
     {
-        var length = 0;
-        var returnedPtr = _EnumerateAll(&length);
-        var outString = StringAlloc.CreateCSharpString((nint)returnedPtr, length);
-        NativeAllocator.Free((nint)returnedPtr);
-        return outString;
+        var count = 0;
+        var ptr = _EnumerateAll(&count);
+        return (ptr, count);
     }
 
     private unsafe static delegate* unmanaged<ulong, int> _UnlockAll;

--- a/managed/src/SwiftlyS2.Generated/Natives/NetMessages.cs
+++ b/managed/src/SwiftlyS2.Generated/Natives/NetMessages.cs
@@ -959,8 +959,7 @@ internal static class NativeNetMessages
 
     private unsafe static delegate* unmanaged<int> _GetCNetMessageSize;
 
-    /// <summary>Compile-time sizeof(CNetMessage). Offset from CNetMessage* to google::protobuf::Message*.</summary>
-    public unsafe static int GetCNetMessageSize()
+    internal unsafe static int GetCNetMessageSize()
     {
         return _GetCNetMessageSize();
     }

--- a/managed/src/SwiftlyS2.Generated/Natives/NetMessages.cs
+++ b/managed/src/SwiftlyS2.Generated/Natives/NetMessages.cs
@@ -908,4 +908,60 @@ internal static class NativeNetMessages
     {
         _RemoveNetMessageServerHookInternal(callbackID);
     }
+
+    private unsafe static delegate* unmanaged<int*, nint, byte*> _DebugString;
+
+    public unsafe static string DebugString(nint protoMsgPtr)
+    {
+        var length = 0;
+        var returnedPtr = _DebugString(&length, protoMsgPtr);
+        var outString = StringAlloc.CreateCSharpString((nint)returnedPtr, length);
+        NativeAllocator.Free((nint)returnedPtr);
+        return outString;
+    }
+
+    private unsafe static delegate* unmanaged<nint, nint> _ParseUserCmdFromMove;
+
+    public unsafe static nint ParseUserCmdFromMove(nint moveMsgPtr)
+    {
+        var ret = _ParseUserCmdFromMove(moveMsgPtr);
+        return ret;
+    }
+
+    private unsafe static delegate* unmanaged<nint, void> _FreeUserCmd;
+
+    public unsafe static void FreeUserCmd(nint cmdPtr)
+    {
+        _FreeUserCmd(cmdPtr);
+    }
+
+    private unsafe static delegate* unmanaged<int*, nint, byte*> _FormatMoveDebugString;
+
+    public unsafe static string FormatMoveDebugString(nint moveMsgPtr)
+    {
+        var length = 0;
+        var returnedPtr = _FormatMoveDebugString(&length, moveMsgPtr);
+        var outString = StringAlloc.CreateCSharpString((nint)returnedPtr, length);
+        NativeAllocator.Free((nint)returnedPtr);
+        return outString;
+    }
+
+    private unsafe static delegate* unmanaged<int*, int, byte*> _GetMessageNameById;
+
+    public unsafe static string GetMessageNameById(int msgId)
+    {
+        var length = 0;
+        var returnedPtr = _GetMessageNameById(&length, msgId);
+        var outString = StringAlloc.CreateCSharpString((nint)returnedPtr, length);
+        NativeAllocator.Free((nint)returnedPtr);
+        return outString;
+    }
+
+    private unsafe static delegate* unmanaged<int> _GetCNetMessageSize;
+
+    /// <summary>Compile-time sizeof(CNetMessage). Offset from CNetMessage* to google::protobuf::Message*.</summary>
+    public unsafe static int GetCNetMessageSize()
+    {
+        return _GetCNetMessageSize();
+    }
 }

--- a/managed/src/SwiftlyS2.Generated/Natives/Schema.cs
+++ b/managed/src/SwiftlyS2.Generated/Natives/Schema.cs
@@ -93,4 +93,18 @@ internal static class NativeSchema
         var ret = _GetDatamapFunction(hash);
         return ret;
     }
+
+    private unsafe static delegate* unmanaged<int*, nint, byte*, byte*> _GetEntityFields;
+
+    public unsafe static string GetEntityFields(nint entity, string className)
+    {
+        return StringAlloc.CreateCString(className, classNameBufferPtr =>
+        {
+            var length = 0;
+            var returnedPtr = _GetEntityFields(&length, entity, (byte*)classNameBufferPtr);
+            var outString = StringAlloc.CreateCSharpString((nint)returnedPtr, length);
+            NativeAllocator.Free((nint)returnedPtr);
+            return outString;
+        });
+    }
 }

--- a/managed/src/SwiftlyS2.Shared/Modules/Convars/IConVarService.cs
+++ b/managed/src/SwiftlyS2.Shared/Modules/Convars/IConVarService.cs
@@ -110,16 +110,24 @@ public interface IConVarService
 
 public record ConVarInfo
 {
+    /// <summary>The convar name (e.g. "sv_cheats").</summary>
     public required string Name { get; init; }
+    /// <summary>Value type: "bool", "int32", "float64", "string", "vector3", etc.</summary>
     public required string Type { get; init; }
-    public required string Default { get; init; }
+    /// <summary>Default value as a string, or empty if none.</summary>
+    public required string DefaultValue { get; init; }
+    /// <summary>Raw flags bitmask (see <see cref="ConvarFlags"/>).</summary>
     public required ulong Flags { get; init; }
+    /// <summary>Help/description text.</summary>
     public required string Description { get; init; }
 }
 
 public record ConCommandInfo
 {
+    /// <summary>The command name (e.g. "give").</summary>
     public required string Name { get; init; }
+    /// <summary>Raw flags bitmask (see <see cref="ConvarFlags"/>).</summary>
     public required ulong Flags { get; init; }
+    /// <summary>Help/description text.</summary>
     public required string Description { get; init; }
 }

--- a/managed/src/SwiftlyS2.Shared/Modules/Convars/IConVarService.cs
+++ b/managed/src/SwiftlyS2.Shared/Modules/Convars/IConVarService.cs
@@ -84,4 +84,28 @@ public interface IConVarService
     /// <param name="name">The name of the convar.</param>
     /// <param name="value">The value to replicate.</param>
     public void ReplicateToAll(string name, string value);
+
+    /// <summary>
+    /// Enumerate all registered convars and return them as a JSON array.
+    /// Each entry has name, type, default, flags (raw uint64), and desc fields.
+    /// </summary>
+    public string EnumerateAllConVars();
+
+    /// <summary>
+    /// Enumerate all registered concommands and return them as a JSON array.
+    /// Each entry has name, flags (raw uint64), and desc fields.
+    /// </summary>
+    public string EnumerateAllCommands();
+
+    /// <summary>
+    /// Remove the specified flags from all convars. Returns count of convars unlocked.
+    /// Default: HIDDEN | DEVELOPMENT_ONLY | CLIENTDLL | DEFENSIVE.
+    /// </summary>
+    public int UnlockAllConVars(ConvarFlags flagsToRemove = ConvarFlags.HIDDEN | ConvarFlags.DEVELOPMENT_ONLY | ConvarFlags.CLIENTDLL | ConvarFlags.DEFENSIVE);
+
+    /// <summary>
+    /// Remove the specified flags from all concommands. Returns count of commands unlocked.
+    /// Default: HIDDEN | DEVELOPMENT_ONLY | CLIENTDLL | DEFENSIVE.
+    /// </summary>
+    public int UnlockAllCommands(ConvarFlags flagsToRemove = ConvarFlags.HIDDEN | ConvarFlags.DEVELOPMENT_ONLY | ConvarFlags.CLIENTDLL | ConvarFlags.DEFENSIVE);
 }

--- a/managed/src/SwiftlyS2.Shared/Modules/Convars/IConVarService.cs
+++ b/managed/src/SwiftlyS2.Shared/Modules/Convars/IConVarService.cs
@@ -86,16 +86,14 @@ public interface IConVarService
     public void ReplicateToAll(string name, string value);
 
     /// <summary>
-    /// Enumerate all registered convars and return them as a JSON array.
-    /// Each entry has name, type, default, flags (raw uint64), and desc fields.
+    /// Enumerate all registered convars.
     /// </summary>
-    public string EnumerateAllConVars();
+    public IReadOnlyList<ConVarInfo> EnumerateAllConVars();
 
     /// <summary>
-    /// Enumerate all registered concommands and return them as a JSON array.
-    /// Each entry has name, flags (raw uint64), and desc fields.
+    /// Enumerate all registered concommands.
     /// </summary>
-    public string EnumerateAllCommands();
+    public IReadOnlyList<ConCommandInfo> EnumerateAllCommands();
 
     /// <summary>
     /// Remove the specified flags from all convars. Returns count of convars unlocked.
@@ -108,4 +106,20 @@ public interface IConVarService
     /// Default: HIDDEN | DEVELOPMENT_ONLY | CLIENTDLL | DEFENSIVE.
     /// </summary>
     public int UnlockAllCommands(ConvarFlags flagsToRemove = ConvarFlags.HIDDEN | ConvarFlags.DEVELOPMENT_ONLY | ConvarFlags.CLIENTDLL | ConvarFlags.DEFENSIVE);
+}
+
+public record ConVarInfo
+{
+    public required string Name { get; init; }
+    public required string Type { get; init; }
+    public required string Default { get; init; }
+    public required ulong Flags { get; init; }
+    public required string Description { get; init; }
+}
+
+public record ConCommandInfo
+{
+    public required string Name { get; init; }
+    public required ulong Flags { get; init; }
+    public required string Description { get; init; }
 }

--- a/managed/src/SwiftlyS2.Shared/Modules/Memory/IMemoryService.cs
+++ b/managed/src/SwiftlyS2.Shared/Modules/Memory/IMemoryService.cs
@@ -124,4 +124,14 @@ public interface IMemoryService
     /// <param name="className">The vtable/schema class name of the entity (for schema lookup).</param>
     /// <returns>JSON string of schema fields, or "[]" if schema not found.</returns>
     public string GetEntityFields( nint entity, string className );
+
+    /// <summary>
+    /// Get the protobuf DebugString for a message pointer (Address from ITypedProtobuf).
+    /// </summary>
+    public string DebugProtobuf( nint protoMsgPtr );
+
+    /// <summary>
+    /// Parse CCLCMsg_Move.data as CSGOUserCmdPB. Returns formatted string with command details.
+    /// </summary>
+    public string FormatMoveDetail( nint moveMsgPtr );
 }

--- a/managed/src/SwiftlyS2.Shared/Modules/Memory/IMemoryService.cs
+++ b/managed/src/SwiftlyS2.Shared/Modules/Memory/IMemoryService.cs
@@ -117,13 +117,12 @@ public interface IMemoryService
     public nint Resize( nint pointer, ulong newSize );
 
     /// <summary>
-    /// Walk all schema fields of an entity and return them as a JSON array.
-    /// Each field has name, type, offset, value, and children (for nested types).
+    /// Walk all schema fields of an entity.
     /// </summary>
     /// <param name="entity">The entity pointer.</param>
     /// <param name="className">The vtable/schema class name of the entity (for schema lookup).</param>
-    /// <returns>JSON string of schema fields, or "[]" if schema not found.</returns>
-    public string GetEntityFields( nint entity, string className );
+    /// <returns>Schema fields with nested children, or an empty list if schema not found.</returns>
+    public IReadOnlyList<EntityFieldInfo> GetEntityFields( nint entity, string className );
 
     /// <summary>
     /// Get the protobuf DebugString for a message pointer (Address from ITypedProtobuf).

--- a/managed/src/SwiftlyS2.Shared/Modules/Memory/IMemoryService.cs
+++ b/managed/src/SwiftlyS2.Shared/Modules/Memory/IMemoryService.cs
@@ -115,4 +115,13 @@ public interface IMemoryService
     /// <param name="newSize">The new size of the memory block.</param>
     /// <returns>The address of the resized memory block.</returns>
     public nint Resize( nint pointer, ulong newSize );
+
+    /// <summary>
+    /// Walk all schema fields of an entity and return them as a JSON array.
+    /// Each field has name, type, offset, value, and children (for nested types).
+    /// </summary>
+    /// <param name="entity">The entity pointer.</param>
+    /// <param name="className">The vtable/schema class name of the entity (for schema lookup).</param>
+    /// <returns>JSON string of schema fields, or "[]" if schema not found.</returns>
+    public string GetEntityFields( nint entity, string className );
 }

--- a/managed/src/SwiftlyS2.Shared/Modules/NetMessages/INetMessageService.cs
+++ b/managed/src/SwiftlyS2.Shared/Modules/NetMessages/INetMessageService.cs
@@ -148,6 +148,23 @@ public interface INetMessageService
   /// <typeparam name="T">Server net message type.</typeparam>
   public void UnhookServerMessageInternal<T>() where T : ITypedProtobuf<T>, INetMessage<T>, IDisposable;
 
+  // ── Raw unhook ────────────────────────────────────────────────────
+
+  /// <summary>
+  /// Unhooks all raw client net message handlers.
+  /// </summary>
+  public void UnhookClientMessageRaw();
+
+  /// <summary>
+  /// Unhooks all raw server net message handlers.
+  /// </summary>
+  public void UnhookServerMessageRaw();
+
+  /// <summary>
+  /// Unhooks all raw server net internal message handlers.
+  /// </summary>
+  public void UnhookServerMessageInternalRaw();
+
   /// <summary>
   /// Creates a new net message of specified type.
   /// </summary>
@@ -163,10 +180,19 @@ public interface INetMessageService
   public void Send<T>( Action<T> configureMessage ) where T : ITypedProtobuf<T>, INetMessage<T>, IDisposable;
 }
 
+/// <summary>
+/// Represents an intercepted network message whose concrete type is not known at compile time.
+/// Provides access to the message identity, raw protobuf fields via <see cref="IProtobufAccessor"/>,
+/// and a human-readable <see cref="GetDebugString"/>.
+/// </summary>
 public interface IUntypedNetMessage
 {
+    /// <summary>The network message ID (e.g. 21 for CCLCMsg_Move).</summary>
     int MessageId { get; }
+    /// <summary>The unscoped message name (e.g. "CCLCMsg_Move").</summary>
     string MessageName { get; }
+    /// <summary>Accessor for reading and writing protobuf fields by name.</summary>
     IProtobufAccessor Accessor { get; }
+    /// <summary>Returns the protobuf message's DebugString (human-readable multi-line text).</summary>
     string GetDebugString();
 }

--- a/managed/src/SwiftlyS2.Shared/Modules/NetMessages/INetMessageService.cs
+++ b/managed/src/SwiftlyS2.Shared/Modules/NetMessages/INetMessageService.cs
@@ -32,6 +32,38 @@ public interface INetMessageService
   /// <returns>The hook result.</returns>
   delegate HookResult ClientNetMessageHandler<T>( T msg, int playerId ) where T : ITypedProtobuf<T>, INetMessage<T>, IDisposable;
 
+  // ── Raw (untyped) handlers ──────────────────────────────────────
+
+  /// <summary>
+  /// Raw handler for ALL client net messages (untyped).
+  /// Receives the message as a google::protobuf::Message* pointer (already offset from CNetMessage*).
+  /// Use <see cref="GetMessageNameById"/> to resolve the message name,
+  /// and <see cref="SwiftlyS2.Shared.Memory.IMemoryService.DebugProtobuf"/> to get its DebugString.
+  /// </summary>
+  delegate HookResult RawClientNetMessageHandler( int playerId, int msgId, nint pMessage );
+
+  /// <summary>
+  /// Raw handler for ALL server net messages (untyped).
+  /// pPlayerMask is a pointer to a uint64 bitmap of recipients.
+  /// pMessage is a google::protobuf::Message* pointer (already offset from CNetMessage*).
+  /// </summary>
+  delegate HookResult RawServerNetMessageHandler( nint pPlayerMask, int msgId, nint pMessage );
+
+  /// <summary>
+  /// Raw handler for ALL server net internal messages (untyped).
+  /// pMessage is a google::protobuf::Message* pointer (already offset from CNetMessage*).
+  /// </summary>
+  delegate HookResult RawServerNetMessageInternalHandler( int playerId, int msgId, nint pMessage );
+
+  /// <summary>
+  /// Get the unscoped name of a net message by its ID.
+  /// </summary>
+  /// <param name="msgId">The net message ID.</param>
+  /// <returns>The unscoped message name, or empty string if not found.</returns>
+  public string GetMessageNameById( int msgId );
+
+  // ── Typed hooks ──────────────────────────────────────────────────
+
   /// <summary>
   /// Hooks a client net message.
   /// </summary>
@@ -55,6 +87,38 @@ public interface INetMessageService
   /// <param name="callback"></param>
   /// <returns></returns>
   public Guid HookServerMessageInternal<T>( ServerNetMessageInternalHandler<T> callback ) where T : ITypedProtobuf<T>, INetMessage<T>, IDisposable;
+
+  // ── Raw hooks (untyped — catch ALL messages) ─────────────────────
+
+  /// <summary>
+  /// Hooks ALL client net messages without type filtering.
+  /// </summary>
+  /// <param name="callback">
+  /// Called for every incoming client → server message.
+  /// Parameters: playerId, msgId, pMessage (raw protobuf pointer).
+  /// </param>
+  /// <returns>Hook identifier for later unhook.</returns>
+  public Guid HookClientMessageRaw( RawClientNetMessageHandler callback );
+
+  /// <summary>
+  /// Hooks ALL server net messages without type filtering.
+  /// </summary>
+  /// <param name="callback">
+  /// Called for every outgoing server → client broadcast message.
+  /// Parameters: pPlayerMask (uint64* recipients bitmap), msgId, pMessage.
+  /// </param>
+  /// <returns>Hook identifier for later unhook.</returns>
+  public Guid HookServerMessageRaw( RawServerNetMessageHandler callback );
+
+  /// <summary>
+  /// Hooks ALL server net internal (unicast) messages without type filtering.
+  /// </summary>
+  /// <param name="callback">
+  /// Called for every outgoing server → client unicast message.
+  /// Parameters: playerId, msgId, pMessage.
+  /// </param>
+  /// <returns>Hook identifier for later unhook.</returns>
+  public Guid HookServerMessageInternalRaw( RawServerNetMessageInternalHandler callback );
 
   /// <summary>
   /// Unhooks a net message handler.

--- a/managed/src/SwiftlyS2.Shared/Modules/NetMessages/INetMessageService.cs
+++ b/managed/src/SwiftlyS2.Shared/Modules/NetMessages/INetMessageService.cs
@@ -36,24 +36,27 @@ public interface INetMessageService
 
   /// <summary>
   /// Raw handler for ALL client net messages (untyped).
-  /// Receives the message as a google::protobuf::Message* pointer (already offset from CNetMessage*).
-  /// Use <see cref="GetMessageNameById"/> to resolve the message name,
-  /// and <see cref="SwiftlyS2.Shared.Memory.IMemoryService.DebugProtobuf"/> to get its DebugString.
   /// </summary>
-  delegate HookResult RawClientNetMessageHandler( int playerId, int msgId, nint pMessage );
+  /// <param name="playerId">The player that sent the message.</param>
+  /// <param name="msg">The untyped net message with MessageId, MessageName, Accessor, and GetDebugString().</param>
+  /// <returns>The hook result.</returns>
+  delegate HookResult RawClientNetMessageHandler( int playerId, IUntypedNetMessage msg );
 
   /// <summary>
   /// Raw handler for ALL server net messages (untyped).
-  /// pPlayerMask is a pointer to a uint64 bitmap of recipients.
-  /// pMessage is a google::protobuf::Message* pointer (already offset from CNetMessage*).
   /// </summary>
-  delegate HookResult RawServerNetMessageHandler( nint pPlayerMask, int msgId, nint pMessage );
+  /// <param name="msg">The untyped net message with MessageId, MessageName, Accessor, and GetDebugString().</param>
+  /// <param name="pPlayerMask">Pointer to a uint64 bitmap of recipients.</param>
+  /// <returns>The hook result.</returns>
+  delegate HookResult RawServerNetMessageHandler( IUntypedNetMessage msg, nint pPlayerMask );
 
   /// <summary>
   /// Raw handler for ALL server net internal messages (untyped).
-  /// pMessage is a google::protobuf::Message* pointer (already offset from CNetMessage*).
   /// </summary>
-  delegate HookResult RawServerNetMessageInternalHandler( int playerId, int msgId, nint pMessage );
+  /// <param name="playerId">The target player ID.</param>
+  /// <param name="msg">The untyped net message with MessageId, MessageName, Accessor, and GetDebugString().</param>
+  /// <returns>The hook result.</returns>
+  delegate HookResult RawServerNetMessageInternalHandler( int playerId, IUntypedNetMessage msg );
 
   /// <summary>
   /// Get the unscoped name of a net message by its ID.
@@ -95,7 +98,8 @@ public interface INetMessageService
   /// </summary>
   /// <param name="callback">
   /// Called for every incoming client → server message.
-  /// Parameters: playerId, msgId, pMessage (raw protobuf pointer).
+  /// The message is encapsulated in <see cref="IUntypedNetMessage"/> which provides
+  /// MessageId, MessageName, an <see cref="IProtobufAccessor"/> for field access, and GetDebugString().
   /// </param>
   /// <returns>Hook identifier for later unhook.</returns>
   public Guid HookClientMessageRaw( RawClientNetMessageHandler callback );
@@ -105,7 +109,7 @@ public interface INetMessageService
   /// </summary>
   /// <param name="callback">
   /// Called for every outgoing server → client broadcast message.
-  /// Parameters: pPlayerMask (uint64* recipients bitmap), msgId, pMessage.
+  /// The message is encapsulated in <see cref="IUntypedNetMessage"/>.
   /// </param>
   /// <returns>Hook identifier for later unhook.</returns>
   public Guid HookServerMessageRaw( RawServerNetMessageHandler callback );
@@ -115,7 +119,7 @@ public interface INetMessageService
   /// </summary>
   /// <param name="callback">
   /// Called for every outgoing server → client unicast message.
-  /// Parameters: playerId, msgId, pMessage.
+  /// The message is encapsulated in <see cref="IUntypedNetMessage"/>.
   /// </param>
   /// <returns>Hook identifier for later unhook.</returns>
   public Guid HookServerMessageInternalRaw( RawServerNetMessageInternalHandler callback );
@@ -157,4 +161,12 @@ public interface INetMessageService
   /// <typeparam name="T">Net message type.</typeparam>
   /// <param name="configureMessage">The action to configure the net message and recipient filter.</param>
   public void Send<T>( Action<T> configureMessage ) where T : ITypedProtobuf<T>, INetMessage<T>, IDisposable;
+}
+
+public interface IUntypedNetMessage
+{
+    int MessageId { get; }
+    string MessageName { get; }
+    IProtobufAccessor Accessor { get; }
+    string GetDebugString();
 }

--- a/managed/src/SwiftlyS2.Shared/Modules/Schemas/ISchemaField.cs
+++ b/managed/src/SwiftlyS2.Shared/Modules/Schemas/ISchemaField.cs
@@ -6,3 +6,12 @@ public interface ISchemaField : INativeHandle {
 
 
 }
+
+public record EntityFieldInfo
+{
+    public required string Name { get; init; }
+    public required string Type { get; init; }
+    public required int Offset { get; init; }
+    public required string Value { get; init; }
+    public List<EntityFieldInfo> Children { get; init; } = [];
+}

--- a/managed/src/SwiftlyS2.Shared/Modules/Schemas/ISchemaField.cs
+++ b/managed/src/SwiftlyS2.Shared/Modules/Schemas/ISchemaField.cs
@@ -7,11 +7,23 @@ public interface ISchemaField : INativeHandle {
 
 }
 
+/// <summary>
+/// Describes a single field in an entity's schema, optionally with nested children
+/// for declared classes, fixed arrays, and collection elements.
+/// </summary>
 public record EntityFieldInfo
 {
+    /// <summary>Field name, or "[N]" for collection/array elements.</summary>
     public required string Name { get; init; }
+    /// <summary>Schema type name (e.g. "int32", "Vector", "CUtlVector", "CCSPlayerController").</summary>
     public required string Type { get; init; }
+    /// <summary>Byte offset from the entity base pointer.</summary>
     public required int Offset { get; init; }
+    /// <summary>Formatted value string. Format depends on Type: scalars are numeric,
+    /// vectors are space-separated floats, strings are raw text, handles are hex.</summary>
     public required string Value { get; init; }
-    public List<EntityFieldInfo> Children { get; init; } = [];
+    /// <summary>Nesting depth (0 = top-level entity field).</summary>
+    public int Depth { get; init; }
+    /// <summary>Nested child fields (empty if the field has no sub-fields).</summary>
+    public IReadOnlyList<EntityFieldInfo> Children { get; init; } = [];
 }

--- a/src/scripting/engine/convars.cpp
+++ b/src/scripting/engine/convars.cpp
@@ -475,3 +475,158 @@ DEFINE_NATIVE("Convars.SetMaxValueAsString", Bridge_Convars_SetMaxValueAsString)
 DEFINE_NATIVE("Convars.GetMaxValueAsString", Bridge_Convars_GetMaxValueAsString);
 DEFINE_NATIVE("Convars.SetValueInternalAsString", Bridge_Convars_SetValueInternalAsString);
 DEFINE_NATIVE("Convars.GetDescription", Bridge_Convars_GetDescription);
+
+// --- ConVar/ConCommand full enumeration and bulk unlock ---
+
+static char* Bridge_Convars_EnumerateAll(int* outSize)
+{
+    static auto memory = g_ifaceService.FetchInterface<IMemoryAllocator>(MEMORYALLOCATOR_INTERFACE_VERSION);
+    static auto cvars = g_ifaceService.FetchInterface<ICvar>(CVAR_INTERFACE_VERSION);
+
+    std::string json = "[";
+    bool first = true;
+
+    for (ConVarRef ref = cvars->FindFirstConVar(); ref.IsValidRef(); ref = cvars->FindNextConVar(ref))
+    {
+        ConVarRefAbstract abstract(ref);
+        auto* data = abstract.GetConVarData();
+        if (!data || !data->m_pszName) continue;
+
+        const char* typeName = "?";
+        switch (data->m_eVarType)
+        {
+            case EConVarType_Bool:       typeName = "bool"; break;
+            case EConVarType_Int16:      typeName = "int16"; break;
+            case EConVarType_UInt16:     typeName = "uint16"; break;
+            case EConVarType_Int32:      typeName = "int32"; break;
+            case EConVarType_UInt32:     typeName = "uint32"; break;
+            case EConVarType_Int64:      typeName = "int64"; break;
+            case EConVarType_UInt64:     typeName = "uint64"; break;
+            case EConVarType_Float32:    typeName = "float32"; break;
+            case EConVarType_Float64:    typeName = "float64"; break;
+            case EConVarType_String:     typeName = "string"; break;
+            case EConVarType_Color:      typeName = "color"; break;
+            case EConVarType_Vector2:    typeName = "vector2"; break;
+            case EConVarType_Vector3:    typeName = "vector3"; break;
+            case EConVarType_Vector4:    typeName = "vector4"; break;
+            case EConVarType_Qangle:     typeName = "qangle"; break;
+            default: break;
+        }
+
+        CBufferString buf;
+        std::string defaultVal = "\"\"";
+        if (data->m_defaultValue)
+        {
+            data->DefaultValueToString(buf);
+            defaultVal = "\"" + std::string(buf.Get()) + "\"";
+        }
+
+        std::string desc = abstract.GetHelpText();
+
+        // Simple manual JSON escaping for name/desc
+        auto esc = [](const std::string& s) -> std::string {
+            std::string out;
+            for (char c : s)
+            {
+                if (c == '"') out += "\\\"";
+                else if (c == '\\') out += "\\\\";
+                else if (c == '\n') out += "\\n";
+                else if (c == '\r') out += "\\r";
+                else if (c == '\t') out += "\\t";
+                else out += c;
+            }
+            return out;
+        };
+
+        if (!first) json += ","; first = false;
+        json += "{\"name\":\"" + esc(data->m_pszName) + "\",\"type\":\"" + typeName +
+                "\",\"default\":" + defaultVal + ",\"flags\":" + std::to_string(data->m_nFlags) +
+                ",\"desc\":\"" + esc(desc) + "\"}";
+    }
+    json += "]";
+
+    int len = (int)json.size();
+    *outSize = len;
+    char* out = (char*)memory->Alloc(len + 1);
+    memory->Copy(out, (void*)json.data(), len);
+    out[len] = '\0';
+    return out;
+}
+
+static char* Bridge_Commands_EnumerateAll(int* outSize)
+{
+    static auto memory = g_ifaceService.FetchInterface<IMemoryAllocator>(MEMORYALLOCATOR_INTERFACE_VERSION);
+    static auto cvars = g_ifaceService.FetchInterface<ICvar>(CVAR_INTERFACE_VERSION);
+
+    std::string json = "[";
+    bool first = true;
+
+    for (ConCommandRef ref = cvars->FindFirstConCommand(); ref.IsValidRef(); ref = cvars->FindNextConCommand(ref))
+    {
+        auto* data = cvars->GetConCommandData(ref);
+        if (!data || !data->m_pszName) continue;
+
+        auto esc = [](const std::string& s) -> std::string {
+            std::string out;
+            for (char c : s)
+            {
+                if (c == '"') out += "\\\"";
+                else if (c == '\\') out += "\\\\";
+                else if (c == '\n') out += "\\n";
+                else if (c == '\r') out += "\\r";
+                else if (c == '\t') out += "\\t";
+                else out += c;
+            }
+            return out;
+        };
+
+        if (!first) json += ","; first = false;
+        json += "{\"name\":\"" + esc(data->m_pszName) + "\",\"flags\":" +
+                std::to_string(data->m_nFlags) + ",\"desc\":\"" +
+                esc(data->m_pszHelpString ? data->m_pszHelpString : "") + "\"}";
+    }
+    json += "]";
+
+    int len = (int)json.size();
+    *outSize = len;
+    char* out = (char*)memory->Alloc(len + 1);
+    memory->Copy(out, (void*)json.data(), len);
+    out[len] = '\0';
+    return out;
+}
+
+static int Bridge_Convars_UnlockAll(uint64_t flagsToRemove)
+{
+    if (flagsToRemove == 0) return 0;
+    static auto cvars = g_ifaceService.FetchInterface<ICvar>(CVAR_INTERFACE_VERSION);
+
+    int unlocked = 0;
+    for (ConVarRef ref = cvars->FindFirstConVar(); ref.IsValidRef(); ref = cvars->FindNextConVar(ref))
+    {
+        ConVarRefAbstract abstract(ref);
+        if (!abstract.IsFlagSet(flagsToRemove)) continue;
+        abstract.RemoveFlags(flagsToRemove);
+        unlocked++;
+    }
+    return unlocked;
+}
+
+static int Bridge_Commands_UnlockAll(uint64_t flagsToRemove)
+{
+    if (flagsToRemove == 0) return 0;
+    static auto cvars = g_ifaceService.FetchInterface<ICvar>(CVAR_INTERFACE_VERSION);
+
+    int unlocked = 0;
+    for (ConCommandRef ref = cvars->FindFirstConCommand(); ref.IsValidRef(); ref = cvars->FindNextConCommand(ref))
+    {
+        if (!ref.IsFlagSet(flagsToRemove)) continue;
+        ref.RemoveFlags(flagsToRemove);
+        unlocked++;
+    }
+    return unlocked;
+}
+
+DEFINE_NATIVE("Convars.EnumerateAll", Bridge_Convars_EnumerateAll);
+DEFINE_NATIVE("Commands.EnumerateAll", Bridge_Commands_EnumerateAll);
+DEFINE_NATIVE("Convars.UnlockAll", Bridge_Convars_UnlockAll);
+DEFINE_NATIVE("Commands.UnlockAll", Bridge_Commands_UnlockAll);

--- a/src/scripting/engine/convars.cpp
+++ b/src/scripting/engine/convars.cpp
@@ -478,121 +478,122 @@ DEFINE_NATIVE("Convars.GetDescription", Bridge_Convars_GetDescription);
 
 // --- ConVar/ConCommand full enumeration and bulk unlock ---
 
-static char* Bridge_Convars_EnumerateAll(int* outSize)
+#pragma pack(push, 1)
+struct ConVarFlatInfo {
+    char name[128];
+    char type[16];
+    char default_value[256];
+    char description[512];
+    uint64_t flags;
+};
+
+struct ConCommandFlatInfo {
+    char name[128];
+    char description[512];
+    uint64_t flags;
+};
+#pragma pack(pop)
+
+static void CopyStr(char* dst, int dstSize, const char* src)
+{
+    if (!src) { dst[0] = '\0'; return; }
+    strncpy(dst, src, dstSize - 1);
+    dst[dstSize - 1] = '\0';
+}
+
+static const char* VarTypeName(EConVarType t)
+{
+    switch (t)
+    {
+        case EConVarType_Bool:       return "bool";
+        case EConVarType_Int16:      return "int16";
+        case EConVarType_UInt16:     return "uint16";
+        case EConVarType_Int32:      return "int32";
+        case EConVarType_UInt32:     return "uint32";
+        case EConVarType_Int64:      return "int64";
+        case EConVarType_UInt64:     return "uint64";
+        case EConVarType_Float32:    return "float32";
+        case EConVarType_Float64:    return "float64";
+        case EConVarType_String:     return "string";
+        case EConVarType_Color:      return "color";
+        case EConVarType_Vector2:    return "vector2";
+        case EConVarType_Vector3:    return "vector3";
+        case EConVarType_Vector4:    return "vector4";
+        case EConVarType_Qangle:     return "qangle";
+        default:                     return "?";
+    }
+}
+
+static void* Bridge_Convars_EnumerateAll(int* outCount)
 {
     static auto memory = g_ifaceService.FetchInterface<IMemoryAllocator>(MEMORYALLOCATOR_INTERFACE_VERSION);
     static auto cvars = g_ifaceService.FetchInterface<ICvar>(CVAR_INTERFACE_VERSION);
 
-    std::string json = "[";
-    bool first = true;
+    int count = 0;
+    for (ConVarRef ref = cvars->FindFirstConVar(); ref.IsValidRef(); ref = cvars->FindNextConVar(ref))
+    {
+        ConVarRefAbstract abstract(ref);
+        if (abstract.GetConVarData() && abstract.GetConVarData()->m_pszName) count++;
+    }
 
+    auto* arr = (ConVarFlatInfo*)memory->Alloc(count * sizeof(ConVarFlatInfo));
+    memset(arr, 0, count * sizeof(ConVarFlatInfo));
+
+    int i = 0;
     for (ConVarRef ref = cvars->FindFirstConVar(); ref.IsValidRef(); ref = cvars->FindNextConVar(ref))
     {
         ConVarRefAbstract abstract(ref);
         auto* data = abstract.GetConVarData();
         if (!data || !data->m_pszName) continue;
 
-        const char* typeName = "?";
-        switch (data->m_eVarType)
-        {
-            case EConVarType_Bool:       typeName = "bool"; break;
-            case EConVarType_Int16:      typeName = "int16"; break;
-            case EConVarType_UInt16:     typeName = "uint16"; break;
-            case EConVarType_Int32:      typeName = "int32"; break;
-            case EConVarType_UInt32:     typeName = "uint32"; break;
-            case EConVarType_Int64:      typeName = "int64"; break;
-            case EConVarType_UInt64:     typeName = "uint64"; break;
-            case EConVarType_Float32:    typeName = "float32"; break;
-            case EConVarType_Float64:    typeName = "float64"; break;
-            case EConVarType_String:     typeName = "string"; break;
-            case EConVarType_Color:      typeName = "color"; break;
-            case EConVarType_Vector2:    typeName = "vector2"; break;
-            case EConVarType_Vector3:    typeName = "vector3"; break;
-            case EConVarType_Vector4:    typeName = "vector4"; break;
-            case EConVarType_Qangle:     typeName = "qangle"; break;
-            default: break;
-        }
+        CopyStr(arr[i].name, sizeof(arr[i].name), data->m_pszName);
+        CopyStr(arr[i].type, sizeof(arr[i].type), VarTypeName(data->m_eVarType));
 
-        CBufferString buf;
-        std::string defaultVal = "\"\"";
         if (data->m_defaultValue)
         {
+            CBufferString buf;
             data->DefaultValueToString(buf);
-            defaultVal = "\"" + std::string(buf.Get()) + "\"";
+            CopyStr(arr[i].default_value, sizeof(arr[i].default_value), buf.Get());
         }
 
-        std::string desc = abstract.GetHelpText();
-
-        // Simple manual JSON escaping for name/desc
-        auto esc = [](const std::string& s) -> std::string {
-            std::string out;
-            for (char c : s)
-            {
-                if (c == '"') out += "\\\"";
-                else if (c == '\\') out += "\\\\";
-                else if (c == '\n') out += "\\n";
-                else if (c == '\r') out += "\\r";
-                else if (c == '\t') out += "\\t";
-                else out += c;
-            }
-            return out;
-        };
-
-        if (!first) json += ","; first = false;
-        json += "{\"name\":\"" + esc(data->m_pszName) + "\",\"type\":\"" + typeName +
-                "\",\"default\":" + defaultVal + ",\"flags\":" + std::to_string(data->m_nFlags) +
-                ",\"desc\":\"" + esc(desc) + "\"}";
+        CopyStr(arr[i].description, sizeof(arr[i].description), abstract.GetHelpText());
+        arr[i].flags = data->m_nFlags;
+        i++;
     }
-    json += "]";
 
-    int len = (int)json.size();
-    *outSize = len;
-    char* out = (char*)memory->Alloc(len + 1);
-    memory->Copy(out, (void*)json.data(), len);
-    out[len] = '\0';
-    return out;
+    *outCount = count;
+    return arr;
 }
 
-static char* Bridge_Commands_EnumerateAll(int* outSize)
+static void* Bridge_Commands_EnumerateAll(int* outCount)
 {
     static auto memory = g_ifaceService.FetchInterface<IMemoryAllocator>(MEMORYALLOCATOR_INTERFACE_VERSION);
     static auto cvars = g_ifaceService.FetchInterface<ICvar>(CVAR_INTERFACE_VERSION);
 
-    std::string json = "[";
-    bool first = true;
+    int count = 0;
+    for (ConCommandRef ref = cvars->FindFirstConCommand(); ref.IsValidRef(); ref = cvars->FindNextConCommand(ref))
+    {
+        auto* data = cvars->GetConCommandData(ref);
+        if (data && data->m_pszName) count++;
+    }
 
+    auto* arr = (ConCommandFlatInfo*)memory->Alloc(count * sizeof(ConCommandFlatInfo));
+    memset(arr, 0, count * sizeof(ConCommandFlatInfo));
+
+    int i = 0;
     for (ConCommandRef ref = cvars->FindFirstConCommand(); ref.IsValidRef(); ref = cvars->FindNextConCommand(ref))
     {
         auto* data = cvars->GetConCommandData(ref);
         if (!data || !data->m_pszName) continue;
 
-        auto esc = [](const std::string& s) -> std::string {
-            std::string out;
-            for (char c : s)
-            {
-                if (c == '"') out += "\\\"";
-                else if (c == '\\') out += "\\\\";
-                else if (c == '\n') out += "\\n";
-                else if (c == '\r') out += "\\r";
-                else if (c == '\t') out += "\\t";
-                else out += c;
-            }
-            return out;
-        };
-
-        if (!first) json += ","; first = false;
-        json += "{\"name\":\"" + esc(data->m_pszName) + "\",\"flags\":" +
-                std::to_string(data->m_nFlags) + ",\"desc\":\"" +
-                esc(data->m_pszHelpString ? data->m_pszHelpString : "") + "\"}";
+        CopyStr(arr[i].name, sizeof(arr[i].name), data->m_pszName);
+        CopyStr(arr[i].description, sizeof(arr[i].description), data->m_pszHelpString ? data->m_pszHelpString : "");
+        arr[i].flags = data->m_nFlags;
+        i++;
     }
-    json += "]";
 
-    int len = (int)json.size();
-    *outSize = len;
-    char* out = (char*)memory->Alloc(len + 1);
-    memory->Copy(out, (void*)json.data(), len);
-    out[len] = '\0';
-    return out;
+    *outCount = count;
+    return arr;
 }
 
 static int Bridge_Convars_UnlockAll(uint64_t flagsToRemove)

--- a/src/scripting/network/netmessages.cpp
+++ b/src/scripting/network/netmessages.cpp
@@ -21,12 +21,19 @@
 
 #include <public/engine/igameeventsystem.h>
 #include <public/networksystem/inetworkmessages.h>
+#include <tier1/bitbuf.h>
 
 #include <api/sdk/recipientfilter.h>
+#include <vector>
 
 #ifdef GetMessage
 #undef GetMessage
 #endif
+
+#include <google/protobuf/message.h>
+#include "usercmd.pb.h"
+#include "cs_usercmd.pb.h"
+#include "netmessages.pb.h"
 
 #define GETCHECK_FIELD(return_value)                                                                                                                                                                                                                           \
     if (!msg)                                                                                                                                                                                                                                                  \
@@ -1022,6 +1029,109 @@ void Bridge_NetMessages_RemoveNetMessageServerHookInternal(uint64_t callbackID)
     netmessages->RemoveServerMessageInternalSendCallback(callbackID);
 }
 
+// ── Protobuf debug helpers ─────────────────────────────────────────────
+
+int Bridge_NetMessages_GetCNetMessageSize()
+{
+    return sizeof(CNetMessage);
+}
+
+char* Bridge_NetMessages_GetMessageNameById(int* outSize, int msgid)
+{
+    auto netmsg = networkMessages->FindNetworkMessageById(msgid);
+    if (!netmsg) { return Bridge_NetMessages_CopyString("", outSize); }
+    return Bridge_NetMessages_CopyString(netmsg->GetUnscopedName(), outSize);
+}
+
+char* Bridge_NetMessages_DebugString(int* outSize, void* pProtoMsg)
+{
+    if (!pProtoMsg) { return Bridge_NetMessages_CopyString("", outSize); }
+    auto* msg = (google::protobuf::Message*)pProtoMsg;
+    return Bridge_NetMessages_CopyString(msg->DebugString(), outSize);
+}
+
+void* Bridge_NetMessages_ParseUserCmdFromMove(void* pMoveMsg)
+{
+    if (!pMoveMsg) return nullptr;
+    auto* msg = (google::protobuf::Message*)pMoveMsg;
+    const auto* desc = msg->GetDescriptor();
+    const auto* field = desc->FindFieldByName("data");
+    if (!field) return nullptr;
+    if (!msg->GetReflection()->HasField(*msg, field)) return nullptr;
+
+    std::string raw = msg->GetReflection()->GetString(*msg, field);
+    bf_read buffer(raw.data(), raw.size());
+
+    auto size = buffer.ReadVarInt32();
+    if (size < 0 || size > 262140) return nullptr;
+    if (size > buffer.GetNumBytesLeft()) return nullptr;
+
+    auto* cmd = new CSGOUserCmdPB();
+
+    if ((buffer.GetNumBitsRead() % 8) == 0)
+    {
+        if (!cmd->ParseFromArray(buffer.GetBasePointer() + buffer.GetNumBytesRead(), size)) { delete cmd; return nullptr; }
+    }
+    else
+    {
+        std::vector<uint8_t> parseBuffer(size);
+        if (!buffer.ReadBytes(parseBuffer.data(), size)) { delete cmd; return nullptr; }
+        if (!cmd->ParseFromArray(parseBuffer.data(), size)) { delete cmd; return nullptr; }
+    }
+
+    return cmd;
+}
+
+// Direct parse from CCLCMsg_Move protobuf to formatted string, using bf_read (matching original CS2ServerGUI)
+char* Bridge_NetMessages_FormatMoveDebugString(int* outSize, void* pProtoMsg)
+{
+    if (!pProtoMsg) { return Bridge_NetMessages_CopyString("", outSize); }
+
+    auto* msg = (google::protobuf::Message*)pProtoMsg;
+    const auto* desc = msg->GetDescriptor();
+    const auto* field = desc->FindFieldByName("data");
+    if (!field) { return Bridge_NetMessages_CopyString("no data field", outSize); }
+    if (!msg->GetReflection()->HasField(*msg, field)) { return Bridge_NetMessages_CopyString("no data", outSize); }
+
+    std::string raw = msg->GetReflection()->GetString(*msg, field);
+    bf_read buffer(raw.data(), raw.size());
+    std::string result;
+
+    while (buffer.GetNumBytesLeft() > 0)
+    {
+        auto size = buffer.ReadVarInt32();
+        if (size <= 0 || size > 262140 || size > buffer.GetNumBytesLeft())
+            break;
+
+        CSGOUserCmdPB userCmd;
+
+        if ((buffer.GetNumBitsRead() % 8) == 0)
+        {
+            if (!userCmd.ParseFromArray(buffer.GetBasePointer() + buffer.GetNumBytesRead(), size))
+                break;
+            buffer.SeekRelative(size * 8);
+        }
+        else
+        {
+            std::vector<uint8_t> parseBuffer(size);
+            if (!buffer.ReadBytes(parseBuffer.data(), size))
+                break;
+            if (!userCmd.ParseFromArray(parseBuffer.data(), size))
+                break;
+        }
+
+        if (!result.empty()) result += "\n";
+        result += userCmd.DebugString();
+    }
+
+    return Bridge_NetMessages_CopyString(result, outSize);
+}
+
+void Bridge_NetMessages_FreeUserCmd(void* pCmd)
+{
+    if (pCmd) delete (CSGOUserCmdPB*)pCmd;
+}
+
 DEFINE_NATIVE("NetMessages.AllocateNetMessageByID", Bridge_NetMessages_AllocateNetMessageByID);
 DEFINE_NATIVE("NetMessages.AllocateNetMessageByPartialName", Bridge_NetMessages_AllocateNetMessageByPartialName);
 DEFINE_NATIVE("NetMessages.DeallocateNetMessage", Bridge_NetMessages_DeallocateNetMessage);
@@ -1105,3 +1215,9 @@ DEFINE_NATIVE("NetMessages.AddNetMessageClientHook", Bridge_NetMessages_AddNetMe
 DEFINE_NATIVE("NetMessages.RemoveNetMessageClientHook", Bridge_NetMessages_RemoveNetMessageClientHook);
 DEFINE_NATIVE("NetMessages.AddNetMessageServerHookInternal", Bridge_NetMessages_AddNetMessageServerHookInternal);
 DEFINE_NATIVE("NetMessages.RemoveNetMessageServerHookInternal", Bridge_NetMessages_RemoveNetMessageServerHookInternal);
+DEFINE_NATIVE("NetMessages.GetCNetMessageSize", Bridge_NetMessages_GetCNetMessageSize);
+DEFINE_NATIVE("NetMessages.GetMessageNameById", Bridge_NetMessages_GetMessageNameById);
+DEFINE_NATIVE("NetMessages.DebugString", Bridge_NetMessages_DebugString);
+DEFINE_NATIVE("NetMessages.ParseUserCmdFromMove", Bridge_NetMessages_ParseUserCmdFromMove);
+DEFINE_NATIVE("NetMessages.FormatMoveDebugString", Bridge_NetMessages_FormatMoveDebugString);
+DEFINE_NATIVE("NetMessages.FreeUserCmd", Bridge_NetMessages_FreeUserCmd);

--- a/src/scripting/sdk/schema.cpp
+++ b/src/scripting/sdk/schema.cpp
@@ -19,6 +19,12 @@
 #include <api/interfaces/manager.h>
 #include <scripting/scripting.h>
 
+#include <public/schemasystem/schemasystem.h>
+#include <public/tier1/utlstring.h>
+
+#include <string>
+#include <vector>
+
 void Bridge_SDK_Schema_SetStateChanged(void* pEntity, uint64_t uHash)
 {
     static auto schema = g_ifaceService.FetchInterface<ISDKSchema>(SDKSCHEMA_INTERFACE_VERSION);
@@ -85,3 +91,251 @@ DEFINE_NATIVE("Schema.GetPropPtr", Bridge_SDK_Schema_GetPropPtr);
 DEFINE_NATIVE("Schema.WritePropPtr", Bridge_SDK_Schema_WritePropPtr);
 DEFINE_NATIVE("Schema.GetVData", Bridge_SDK_Schema_GetVData);
 DEFINE_NATIVE("Schema.GetDatamapFunction", Bridge_SDK_Schema_GetDatamapFunction);
+
+// ── Entity Schema Field Walker ──────────────────────────────────────────
+// Recursively walks CSchemaClassInfo tree for an entity, outputting JSON
+// with field name, type, offset, value, and nested children.
+
+static inline int  PeekI32(const void* p) { int v; memcpy(&v, p, 4); return v; }
+static inline unsigned PeekU32(const void* p) { unsigned v; memcpy(&v, p, 4); return v; }
+static inline float PeekF32(const void* p) { float v; memcpy(&v, p, 4); return v; }
+static inline long long PeekI64(const void* p) { long long v; memcpy(&v, p, 8); return v; }
+static inline void* PeekPtr(const void* p) { void* v; memcpy(&v, p, sizeof(v)); return v; }
+
+// ── JSON string escaping with UTF-8 → \uXXXX ──────────────────────────
+static std::string JsonEscape(const std::string& s) {
+    std::string out;
+    for (size_t i = 0; i < s.size(); ) {
+        unsigned char c = (unsigned char)s[i];
+        if (c == '"' || c == '\\') { out += '\\'; out += (char)c; i++; }
+        else if (c < 0x20) {                                        // control character → \u00XX
+            char e[8]; snprintf(e, sizeof(e), "\\u%04x", c); out += e; i++;
+        } else if (c >= 0x80) {
+            // Check first byte to determine UTF-8 sequence length
+            int len = 0; unsigned cp = 0;
+            if      (c < 0xE0) { len = 2; cp = c & 0x1F; }         // 2-byte sequence (Latin, Greek, etc.)
+            else if (c < 0xF0) { len = 3; cp = c & 0x0F; }         // 3-byte sequence (CJK, etc.)
+            else if (c < 0xF8) { len = 4; cp = c & 0x07; }         // 4-byte sequence (emoji, etc.)
+
+            if (len >= 2 && i + len <= s.size()) {
+                bool ok = true;
+                for (int j = 1; ok && j < len; j++) {
+                    unsigned char nc = (unsigned char)s[i + j];
+                    if ((nc >> 6) != 2) ok = false;                 // continuation byte must start with bits '10'
+                    else cp = (cp << 6) | (nc & 0x3F);
+                }
+                if (ok) {
+                    if (cp <= 0xFFFF) { char e[8]; snprintf(e,sizeof(e),"\\u%04x",cp); out += e; }
+                    else {
+                        // Encode as UTF-16 surrogate pair (U+D800..U+DFFF)
+                        unsigned hi = 0xD800 + ((cp - 0x10000) >> 10);
+                        unsigned lo = 0xDC00 + ((cp - 0x10000) & 0x3FF);
+                        char e[14]; snprintf(e,sizeof(e),"\\u%04x\\u%04x",hi,lo); out += e;
+                    }
+                    i += len; continue;
+                }
+            }
+            // Invalid UTF-8 byte — escape it as-is
+            char e[8]; snprintf(e,sizeof(e),"\\u%04x",c); out += e; i++;
+        } else { out += s[i++]; }
+    }
+    return out;
+}
+
+// ── Type name lookup ────────────────────────────────────────────────────
+static const char* GetTypeName(CSchemaType* pType) {
+    auto cat = pType->m_eTypeCategory;
+    if (cat == SCHEMA_TYPE_DECLARED_CLASS) {
+        auto* dc = (CSchemaType_DeclaredClass*)pType;
+        return dc->m_pClassInfo ? dc->m_pClassInfo->m_pszName : "class";
+    }
+    if (cat == SCHEMA_TYPE_POINTER) return "ptr";
+    if (cat == SCHEMA_TYPE_ATOMIC) {
+        if (pType->m_eAtomicCategory == SCHEMA_ATOMIC_COLLECTION_OF_T) return "CUtlVector";
+        if (pType->m_eAtomicCategory == SCHEMA_ATOMIC_T) return "CHandle";
+        auto* at = (CSchemaType_Atomic*)pType;
+        return at->m_pAtomicInfo ? at->m_pAtomicInfo->m_pszName : "atomic";
+    }
+    if (cat == SCHEMA_TYPE_FIXED_ARRAY) return "fixedarray";
+    if (cat == SCHEMA_TYPE_DECLARED_ENUM) return "enum";
+    if (cat == SCHEMA_TYPE_BUILTIN) {
+        static const char* kBuiltin[] = { "bool","int8","uint8","int16","uint16","int32","uint32","int64","uint64","float","double" };
+        int idx = (int)((CSchemaType_Builtin*)pType)->m_eBuiltinType;
+        return (idx >= 0 && idx < 10) ? kBuiltin[idx] : "builtin";
+    }
+    return "?";
+}
+
+// ── Value formatting ────────────────────────────────────────────────────
+static std::string FormatAtomicValue(void* addr, CSchemaType_Atomic* pType) {
+    if (!pType->m_pAtomicInfo) return "?";
+    const char* n = pType->m_pAtomicInfo->m_pszName; if (!n) return "?";
+    char b[256];
+
+    // Vector / Color types — read known layout
+    if (!strcmp(n, "Vector")) { float* v = (float*)addr; snprintf(b,sizeof(b),"%f %f %f",(double)v[0],(double)v[1],(double)v[2]); return b; }
+    if (!strcmp(n, "Vector2D")) { float* v = (float*)addr; snprintf(b,sizeof(b),"%f %f",(double)v[0],(double)v[1]); return b; }
+    if (!strcmp(n, "Vector4D")) { float* v = (float*)addr; snprintf(b,sizeof(b),"%f %f %f %f",(double)v[0],(double)v[1],(double)v[2],(double)v[3]); return b; }
+    if (!strcmp(n, "QAngle")) { float* v = (float*)addr; snprintf(b,sizeof(b),"%f %f %f",(double)v[0],(double)v[1],(double)v[2]); return b; }
+    if (!strcmp(n, "Color")) { uint8_t* c = (uint8_t*)addr; snprintf(b,sizeof(b),"%d %d %d %d",c[0],c[1],c[2],c[3]); return b; }
+    // String types
+    if (!strcmp(n, "CUtlString")) { const char* s = *(const char**)addr; return s ? "\""+std::string(s)+"\"" : "\"\""; }
+    if (!strcmp(n, "CUtlStringToken")) { snprintf(b,sizeof(b),"hash=%u",PeekU32(addr)); return b; }
+    // Numeric scalars
+    if (!strcmp(n, "float32")) { snprintf(b,sizeof(b),"%f",(double)PeekF32(addr)); return b; }
+    if (!strcmp(n, "float64")) { double v; memcpy(&v,addr,8); snprintf(b,sizeof(b),"%g",v); return b; }
+    if (!strcmp(n, "int32"))  { snprintf(b,sizeof(b),"%d",PeekI32(addr)); return b; }
+    if (!strcmp(n, "uint32")) { snprintf(b,sizeof(b),"%u",PeekU32(addr)); return b; }
+    if (!strcmp(n, "int64"))  { snprintf(b,sizeof(b),"%lld",PeekI64(addr)); return b; }
+    if (!strcmp(n, "uint64")) { unsigned long long v; memcpy(&v,addr,8); snprintf(b,sizeof(b),"%llu",v); return b; }
+    if (!strcmp(n, "bool"))   { return PeekI32(addr) ? "true" : "false"; }
+    // Entity handles
+    if (!strcmp(n, "CEntityIndex")) { snprintf(b,sizeof(b),"#%d",PeekI32(addr)); return b; }
+    if (!strcmp(n, "CEntityHandle") || !strcmp(n, "CHandle")) { unsigned r = PeekU32(addr); snprintf(b,sizeof(b),"#%u (e=%u s=%u)",r,r&0x3FFF,r>>14); return b; }
+    if (!strcmp(n, "CNetworkedQuantizedFloat")) { snprintf(b,sizeof(b),"%f",(double)PeekF32(addr)); return b; }
+    snprintf(b,sizeof(b),"?(%s)",n); return b;
+}
+
+static std::string FormatBuiltinValue(void* addr, CSchemaType_Builtin* bt) {
+    char b[64];
+    switch (bt->m_eBuiltinType) {
+    case SCHEMA_BUILTIN_TYPE_BOOL:    return PeekI32(addr) ? "true" : "false";
+    case SCHEMA_BUILTIN_TYPE_CHAR:    case SCHEMA_BUILTIN_TYPE_INT8:  snprintf(b,sizeof(b),"%d",*(int8_t*)addr); break;
+    case SCHEMA_BUILTIN_TYPE_UINT8:   snprintf(b,sizeof(b),"%u",*(uint8_t*)addr); break;
+    case SCHEMA_BUILTIN_TYPE_INT16:   snprintf(b,sizeof(b),"%d",*(int16_t*)addr); break;
+    case SCHEMA_BUILTIN_TYPE_UINT16:  snprintf(b,sizeof(b),"%u",*(uint16_t*)addr); break;
+    case SCHEMA_BUILTIN_TYPE_INT32:   snprintf(b,sizeof(b),"%d",PeekI32(addr)); break;
+    case SCHEMA_BUILTIN_TYPE_UINT32:  snprintf(b,sizeof(b),"%u",PeekU32(addr)); break;
+    case SCHEMA_BUILTIN_TYPE_INT64:   snprintf(b,sizeof(b),"%lld",PeekI64(addr)); break;
+    case SCHEMA_BUILTIN_TYPE_UINT64:  { unsigned long long v; memcpy(&v,addr,8); snprintf(b,sizeof(b),"%llu",v); break; }
+    case SCHEMA_BUILTIN_TYPE_FLOAT32: snprintf(b,sizeof(b),"%f",(double)PeekF32(addr)); break;
+    case SCHEMA_BUILTIN_TYPE_FLOAT64: { double v; memcpy(&v,addr,8); snprintf(b,sizeof(b),"%g",v); break; }
+    default: return "?";
+    }
+    return b;
+}
+
+// Reads value at addr for pType, sets isNested if children should be expanded
+static void FormatFieldValue(void* addr, CSchemaType* pType, bool& isNested, std::string& out) {
+    if (!addr) { out = "[null]"; return; }
+    auto cat = pType->m_eTypeCategory;
+
+    if (cat == SCHEMA_TYPE_BUILTIN) { out = FormatBuiltinValue(addr, (CSchemaType_Builtin*)pType); return; }
+    if (cat == SCHEMA_TYPE_POINTER) { void* p = PeekPtr(addr); char b[32]; snprintf(b,sizeof(b),p?"0x%p":"nullptr",p); out = b; return; }
+    if (cat == SCHEMA_TYPE_ATOMIC) {
+        auto a = pType->m_eAtomicCategory;
+        if (a == SCHEMA_ATOMIC_PLAIN || a == SCHEMA_ATOMIC_T) { out = FormatAtomicValue(addr, (CSchemaType_Atomic*)pType); return; }
+    }
+    if (cat == SCHEMA_TYPE_DECLARED_CLASS) {
+        auto* dc = (CSchemaType_DeclaredClass*)pType;
+        out = dc->m_pClassInfo ? dc->m_pClassInfo->m_pszName : "class";
+        isNested = true; return;
+    }
+    if (cat == SCHEMA_TYPE_DECLARED_ENUM) {
+        auto* de = (CSchemaType_DeclaredEnum*)pType;
+        if (de->m_pEnumInfo)
+            for (int i = 0; i < de->m_pEnumInfo->m_nEnumeratorCount; i++)
+                if (de->m_pEnumInfo->m_pEnumerators[i].m_nValue == PeekI32(addr))
+                    { out = de->m_pEnumInfo->m_pEnumerators[i].m_pszName; return; }
+        char b[32]; snprintf(b,sizeof(b),"%d",PeekI32(addr)); out = b; return;
+    }
+    if (cat == SCHEMA_TYPE_FIXED_ARRAY) {
+        auto* fa = (CSchemaType_FixedArray*)pType;
+        // Char arrays are treated as strings
+        if (fa->m_pElementType->m_eTypeCategory == SCHEMA_TYPE_BUILTIN &&
+            ((CSchemaType_Builtin*)fa->m_pElementType)->m_eBuiltinType == SCHEMA_BUILTIN_TYPE_CHAR)
+            { out = "\"" + std::string((char*)addr) + "\""; return; }
+        isNested = true; return;
+    }
+    out = "?";
+}
+
+// Helper: append one element of a collection/fixed-array as JSON
+static void WalkSchemaFields(void* pEntity, CSchemaClassInfo* pSchema, std::string& json, int depth);
+
+static void AppendElement(void* elem, CSchemaType* elemType, int index, int offset, std::string& json, int depth) {
+    std::string val; bool nest = false;
+    FormatFieldValue(elem, elemType, nest, val);
+    json += "{\"name\":\"[" + std::to_string(index) + "]\",\"type\":\"elem\",\"offset\":" + std::to_string(offset) + ",\"value\":\"" + JsonEscape(val) + "\",\"children\":";
+    if (nest && depth < 4 && elemType->m_eTypeCategory == SCHEMA_TYPE_DECLARED_CLASS) {
+        auto* dc = (CSchemaType_DeclaredClass*)elemType;
+        json += "[";
+        if (dc->m_pClassInfo) WalkSchemaFields(elem, dc->m_pClassInfo, json, depth + 1);
+        if (!json.empty() && json.back() == ',') json.pop_back();
+        json += "]";
+    } else json += "[]";
+    json += "},";
+}
+
+static void WalkSchemaFields(void* pEntity, CSchemaClassInfo* pSchema, std::string& json, int depth) {
+    if (!pEntity || !pSchema || depth > 4) return;
+
+    for (int i = 0; i < pSchema->m_nFieldCount; i++) {
+        auto& field = pSchema->m_pFields[i];
+        auto* pType = field.m_pType; if (!pType) continue;
+        void* fieldPtr = (uint8_t*)pEntity + field.m_nSingleInheritanceOffset;
+
+        std::string val; bool isNested = false;
+        FormatFieldValue(fieldPtr, pType, isNested, val);
+
+        json += "{\"name\":\"" + JsonEscape(field.m_pszName ? field.m_pszName : "") + "\"";
+        json += ",\"type\":\"" + JsonEscape(GetTypeName(pType)) + "\"";
+        json += ",\"offset\":" + std::to_string(field.m_nSingleInheritanceOffset);
+        json += ",\"value\":\"" + JsonEscape(val) + "\"";
+        json += ",\"children\":";
+
+        if (isNested && depth < 4) {
+            size_t start = json.size(); json += "[";
+            auto cat = pType->m_eTypeCategory;
+
+            if (cat == SCHEMA_TYPE_DECLARED_CLASS) {
+                auto* dc = (CSchemaType_DeclaredClass*)pType;
+                if (dc->m_pClassInfo) {
+                    WalkSchemaFields(fieldPtr, dc->m_pClassInfo, json, depth + 1);
+                    for (int b = 0; b < dc->m_pClassInfo->m_nBaseClassCount; b++)
+                        WalkSchemaFields(fieldPtr, dc->m_pClassInfo->m_pBaseClasses[b].m_pClass, json, depth + 1);
+                }
+            } else if (cat == SCHEMA_TYPE_ATOMIC && pType->m_eAtomicCategory == SCHEMA_ATOMIC_COLLECTION_OF_T) {
+                auto* col = (CSchemaType_Atomic_CollectionOfT*)pType;
+                int count = (int)(intptr_t)col->m_pfnManipulator(SCHEMA_COLLECTION_MANIPULATOR_ACTION_GET_COUNT, fieldPtr, 0, 0);
+                for (int ei = 0; ei < count && ei < 50; ei++)
+                    AppendElement((void*)col->m_pfnManipulator(SCHEMA_COLLECTION_MANIPULATOR_ACTION_GET_ELEMENT_CONST, fieldPtr, ei, 0), col->m_pTemplateType, ei, 0, json, depth + 1);
+            } else if (cat == SCHEMA_TYPE_FIXED_ARRAY) {
+                auto* fa = (CSchemaType_FixedArray*)pType;
+                for (int ei = 0; ei < fa->m_nElementCount && ei < 50; ei++)
+                    AppendElement((uint8_t*)fieldPtr + fa->m_nElementSize * ei, fa->m_pElementType, ei, (int)(fa->m_nElementSize * ei), json, depth + 1);
+            }
+
+            if (json.size() == start + 1) json += "]";
+            else { if (json.back() == ',') json.pop_back(); json += "]"; }
+        } else json += "[]";
+        json += "},";
+    }
+    for (int i = 0; i < pSchema->m_nBaseClassCount; i++)
+        WalkSchemaFields(pEntity, pSchema->m_pBaseClasses[i].m_pClass, json, depth);
+}
+
+char* Bridge_SDK_Schema_GetEntityFields(int* outSize, void* pEntity, const char* className)
+{
+    static auto memory = g_ifaceService.FetchInterface<IMemoryAllocator>(MEMORYALLOCATOR_INTERFACE_VERSION);
+    if (!pEntity || !className || !className[0]) { *outSize = 2; char* o = (char*)memory->Alloc(3); memcpy(o,"[]",2); o[2]=0; return o; }
+
+    static auto ss = g_ifaceService.FetchInterface<ISchemaSystem>(SCHEMASYSTEM_INTERFACE_VERSION);
+    auto* scope = ss ? ss->FindTypeScopeForModule("server.dll") : nullptr;
+    auto* pSchema = scope ? scope->FindDeclaredClass(className).Get() : nullptr;
+
+    if (!pSchema) { *outSize = 2; char* o = (char*)memory->Alloc(3); memcpy(o,"[]",2); o[2]=0; return o; }
+
+    std::string json = "[";
+    WalkSchemaFields(pEntity, pSchema, json, 0);
+    if (json.size() > 1 && json.back() == ',') json.pop_back();
+    json += "]";
+
+    int len = (int)json.size(); *outSize = len;
+    char* o = (char*)memory->Alloc(len + 1);
+    memory->Copy(o, (void*)json.data(), len);
+    o[len] = 0;
+    return o;
+}
+
+DEFINE_NATIVE("Schema.GetEntityFields", Bridge_SDK_Schema_GetEntityFields);

--- a/src/scripting/sdk/schema.cpp
+++ b/src/scripting/sdk/schema.cpp
@@ -93,54 +93,14 @@ DEFINE_NATIVE("Schema.GetVData", Bridge_SDK_Schema_GetVData);
 DEFINE_NATIVE("Schema.GetDatamapFunction", Bridge_SDK_Schema_GetDatamapFunction);
 
 // ── Entity Schema Field Walker ──────────────────────────────────────────
-// Recursively walks CSchemaClassInfo tree for an entity, outputting JSON
-// with field name, type, offset, value, and nested children.
+// Recursively walks CSchemaClassInfo tree for an entity, outputting
+// tab-separated lines: depth\tname\ttype\toffset\tvalue\n
 
 static inline int  PeekI32(const void* p) { int v; memcpy(&v, p, 4); return v; }
 static inline unsigned PeekU32(const void* p) { unsigned v; memcpy(&v, p, 4); return v; }
 static inline float PeekF32(const void* p) { float v; memcpy(&v, p, 4); return v; }
 static inline long long PeekI64(const void* p) { long long v; memcpy(&v, p, 8); return v; }
 static inline void* PeekPtr(const void* p) { void* v; memcpy(&v, p, sizeof(v)); return v; }
-
-// ── JSON string escaping with UTF-8 → \uXXXX ──────────────────────────
-static std::string JsonEscape(const std::string& s) {
-    std::string out;
-    for (size_t i = 0; i < s.size(); ) {
-        unsigned char c = (unsigned char)s[i];
-        if (c == '"' || c == '\\') { out += '\\'; out += (char)c; i++; }
-        else if (c < 0x20) {                                        // control character → \u00XX
-            char e[8]; snprintf(e, sizeof(e), "\\u%04x", c); out += e; i++;
-        } else if (c >= 0x80) {
-            // Check first byte to determine UTF-8 sequence length
-            int len = 0; unsigned cp = 0;
-            if      (c < 0xE0) { len = 2; cp = c & 0x1F; }         // 2-byte sequence (Latin, Greek, etc.)
-            else if (c < 0xF0) { len = 3; cp = c & 0x0F; }         // 3-byte sequence (CJK, etc.)
-            else if (c < 0xF8) { len = 4; cp = c & 0x07; }         // 4-byte sequence (emoji, etc.)
-
-            if (len >= 2 && i + len <= s.size()) {
-                bool ok = true;
-                for (int j = 1; ok && j < len; j++) {
-                    unsigned char nc = (unsigned char)s[i + j];
-                    if ((nc >> 6) != 2) ok = false;                 // continuation byte must start with bits '10'
-                    else cp = (cp << 6) | (nc & 0x3F);
-                }
-                if (ok) {
-                    if (cp <= 0xFFFF) { char e[8]; snprintf(e,sizeof(e),"\\u%04x",cp); out += e; }
-                    else {
-                        // Encode as UTF-16 surrogate pair (U+D800..U+DFFF)
-                        unsigned hi = 0xD800 + ((cp - 0x10000) >> 10);
-                        unsigned lo = 0xDC00 + ((cp - 0x10000) & 0x3FF);
-                        char e[14]; snprintf(e,sizeof(e),"\\u%04x\\u%04x",hi,lo); out += e;
-                    }
-                    i += len; continue;
-                }
-            }
-            // Invalid UTF-8 byte — escape it as-is
-            char e[8]; snprintf(e,sizeof(e),"\\u%04x",c); out += e; i++;
-        } else { out += s[i++]; }
-    }
-    return out;
-}
 
 // ── Type name lookup ────────────────────────────────────────────────────
 static const char* GetTypeName(CSchemaType* pType) {
@@ -241,33 +201,44 @@ static void FormatFieldValue(void* addr, CSchemaType* pType, bool& isNested, std
     }
     if (cat == SCHEMA_TYPE_FIXED_ARRAY) {
         auto* fa = (CSchemaType_FixedArray*)pType;
-        // Char arrays are treated as strings
         if (fa->m_pElementType->m_eTypeCategory == SCHEMA_TYPE_BUILTIN &&
             ((CSchemaType_Builtin*)fa->m_pElementType)->m_eBuiltinType == SCHEMA_BUILTIN_TYPE_CHAR)
-            { out = "\"" + std::string((char*)addr) + "\""; return; }
+            { out = std::string((char*)addr); return; }
         isNested = true; return;
     }
     out = "?";
 }
 
-// Helper: append one element of a collection/fixed-array as JSON
-static void WalkSchemaFields(void* pEntity, CSchemaClassInfo* pSchema, std::string& json, int depth);
+static void WalkSchemaFields(void* pEntity, CSchemaClassInfo* pSchema, std::string& out, int depth);
 
-static void AppendElement(void* elem, CSchemaType* elemType, int index, int offset, std::string& json, int depth) {
-    std::string val; bool nest = false;
-    FormatFieldValue(elem, elemType, nest, val);
-    json += "{\"name\":\"[" + std::to_string(index) + "]\",\"type\":\"elem\",\"offset\":" + std::to_string(offset) + ",\"value\":\"" + JsonEscape(val) + "\",\"children\":";
-    if (nest && depth < 4 && elemType->m_eTypeCategory == SCHEMA_TYPE_DECLARED_CLASS) {
-        auto* dc = (CSchemaType_DeclaredClass*)elemType;
-        json += "[";
-        if (dc->m_pClassInfo) WalkSchemaFields(elem, dc->m_pClassInfo, json, depth + 1);
-        if (!json.empty() && json.back() == ',') json.pop_back();
-        json += "]";
-    } else json += "[]";
-    json += "},";
+static void AppendSchemaLine(std::string& out, int depth, const char* name, const char* type, int offset, const std::string& value)
+{
+    out += std::to_string(depth);
+    out += '\t';
+    out += name ? name : "";
+    out += '\t';
+    out += type ? type : "";
+    out += '\t';
+    out += std::to_string(offset);
+    out += '\t';
+    out += value;
+    out += '\n';
 }
 
-static void WalkSchemaFields(void* pEntity, CSchemaClassInfo* pSchema, std::string& json, int depth) {
+static void AppendElement(void* elem, CSchemaType* elemType, int index, int offset, std::string& out, int depth) {
+    std::string val; bool nest = false;
+    FormatFieldValue(elem, elemType, nest, val);
+
+    char nameBuf[32]; snprintf(nameBuf, sizeof(nameBuf), "[%d]", index);
+    AppendSchemaLine(out, depth, nameBuf, GetTypeName(elemType), offset, val);
+
+    if (nest && depth < 4 && elemType->m_eTypeCategory == SCHEMA_TYPE_DECLARED_CLASS) {
+        auto* dc = (CSchemaType_DeclaredClass*)elemType;
+        if (dc->m_pClassInfo) WalkSchemaFields(elem, dc->m_pClassInfo, out, depth + 1);
+    }
+}
+
+static void WalkSchemaFields(void* pEntity, CSchemaClassInfo* pSchema, std::string& out, int depth) {
     if (!pEntity || !pSchema || depth > 4) return;
 
     for (int i = 0; i < pSchema->m_nFieldCount; i++) {
@@ -278,62 +249,53 @@ static void WalkSchemaFields(void* pEntity, CSchemaClassInfo* pSchema, std::stri
         std::string val; bool isNested = false;
         FormatFieldValue(fieldPtr, pType, isNested, val);
 
-        json += "{\"name\":\"" + JsonEscape(field.m_pszName ? field.m_pszName : "") + "\"";
-        json += ",\"type\":\"" + JsonEscape(GetTypeName(pType)) + "\"";
-        json += ",\"offset\":" + std::to_string(field.m_nSingleInheritanceOffset);
-        json += ",\"value\":\"" + JsonEscape(val) + "\"";
-        json += ",\"children\":";
+        AppendSchemaLine(out, depth, field.m_pszName, GetTypeName(pType), field.m_nSingleInheritanceOffset, val);
 
         if (isNested && depth < 4) {
-            size_t start = json.size(); json += "[";
             auto cat = pType->m_eTypeCategory;
 
             if (cat == SCHEMA_TYPE_DECLARED_CLASS) {
                 auto* dc = (CSchemaType_DeclaredClass*)pType;
                 if (dc->m_pClassInfo) {
-                    WalkSchemaFields(fieldPtr, dc->m_pClassInfo, json, depth + 1);
+                    WalkSchemaFields(fieldPtr, dc->m_pClassInfo, out, depth + 1);
                     for (int b = 0; b < dc->m_pClassInfo->m_nBaseClassCount; b++)
-                        WalkSchemaFields(fieldPtr, dc->m_pClassInfo->m_pBaseClasses[b].m_pClass, json, depth + 1);
+                        WalkSchemaFields(fieldPtr, dc->m_pClassInfo->m_pBaseClasses[b].m_pClass, out, depth + 1);
                 }
             } else if (cat == SCHEMA_TYPE_ATOMIC && pType->m_eAtomicCategory == SCHEMA_ATOMIC_COLLECTION_OF_T) {
                 auto* col = (CSchemaType_Atomic_CollectionOfT*)pType;
                 int count = (int)(intptr_t)col->m_pfnManipulator(SCHEMA_COLLECTION_MANIPULATOR_ACTION_GET_COUNT, fieldPtr, 0, 0);
                 for (int ei = 0; ei < count && ei < 50; ei++)
-                    AppendElement((void*)col->m_pfnManipulator(SCHEMA_COLLECTION_MANIPULATOR_ACTION_GET_ELEMENT_CONST, fieldPtr, ei, 0), col->m_pTemplateType, ei, 0, json, depth + 1);
+                    AppendElement((void*)col->m_pfnManipulator(SCHEMA_COLLECTION_MANIPULATOR_ACTION_GET_ELEMENT_CONST, fieldPtr, ei, 0), col->m_pTemplateType, ei, 0, out, depth + 1);
             } else if (cat == SCHEMA_TYPE_FIXED_ARRAY) {
                 auto* fa = (CSchemaType_FixedArray*)pType;
                 for (int ei = 0; ei < fa->m_nElementCount && ei < 50; ei++)
-                    AppendElement((uint8_t*)fieldPtr + fa->m_nElementSize * ei, fa->m_pElementType, ei, (int)(fa->m_nElementSize * ei), json, depth + 1);
+                    AppendElement((uint8_t*)fieldPtr + fa->m_nElementSize * ei, fa->m_pElementType, ei, (int)(fa->m_nElementSize * ei), out, depth + 1);
             }
-
-            if (json.size() == start + 1) json += "]";
-            else { if (json.back() == ',') json.pop_back(); json += "]"; }
-        } else json += "[]";
-        json += "},";
+        }
     }
     for (int i = 0; i < pSchema->m_nBaseClassCount; i++)
-        WalkSchemaFields(pEntity, pSchema->m_pBaseClasses[i].m_pClass, json, depth);
+        WalkSchemaFields(pEntity, pSchema->m_pBaseClasses[i].m_pClass, out, depth);
 }
 
 char* Bridge_SDK_Schema_GetEntityFields(int* outSize, void* pEntity, const char* className)
 {
     static auto memory = g_ifaceService.FetchInterface<IMemoryAllocator>(MEMORYALLOCATOR_INTERFACE_VERSION);
-    if (!pEntity || !className || !className[0]) { *outSize = 2; char* o = (char*)memory->Alloc(3); memcpy(o,"[]",2); o[2]=0; return o; }
+    if (!pEntity || !className || !className[0]) { *outSize = 0; return (char*)memory->Alloc(1); }
 
     static auto ss = g_ifaceService.FetchInterface<ISchemaSystem>(SCHEMASYSTEM_INTERFACE_VERSION);
     auto* scope = ss ? ss->FindTypeScopeForModule("server.dll") : nullptr;
     auto* pSchema = scope ? scope->FindDeclaredClass(className).Get() : nullptr;
 
-    if (!pSchema) { *outSize = 2; char* o = (char*)memory->Alloc(3); memcpy(o,"[]",2); o[2]=0; return o; }
+    if (!pSchema) { *outSize = 0; return (char*)memory->Alloc(1); }
 
-    std::string json = "[";
-    WalkSchemaFields(pEntity, pSchema, json, 0);
-    if (json.size() > 1 && json.back() == ',') json.pop_back();
-    json += "]";
+    std::string out;
+    WalkSchemaFields(pEntity, pSchema, out, 0);
 
-    int len = (int)json.size(); *outSize = len;
+    int len = (int)out.size();
+    *outSize = len;
+    if (len == 0) return (char*)memory->Alloc(1);
     char* o = (char*)memory->Alloc(len + 1);
-    memory->Copy(o, (void*)json.data(), len);
+    memory->Copy(o, (void*)out.data(), len);
     o[len] = 0;
     return o;
 }


### PR DESCRIPTION
## Description

This PR bundles two related features for the SwiftlyS2 plugin API:

### 1. Raw (untyped) net message hooks

Add `HookClientMessageRaw`, `HookServerMessageRaw`, `HookServerMessageInternalRaw` to
`INetMessageService`, allowing plugins to capture **all** network messages with a single
handler instead of registering per-type hooks for hundreds of message types. Also adds
`GetMessageNameById` for human-readable message names and `GetCNetMessageSize` to eliminate
the hardcoded `CNetMessage` → `google::protobuf::Message` pointer offset.

The design is directly inspired by the original [CS2ServerGUI](https://github.com/Source2ZE/CS2ServerGUI)
architecture (a single `FilterMessage` + `SendNetMessage` vtable hook pair).

### 2. ConVar/Command enumeration, unlock, and entity schema field walker

Add native bridges for enumerating all ConVars and Commands (name, description, flags,
value), unlocking them by removing hidden/development/defensive flags, and walking all schema
fields of an entity with their names, types, offsets, and values — returned as JSON for
easy consumption by plugins.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- [x] Native changes (C++)
- [x] Managed Changes (C#)
- [x] API additions/modifications
- [ ] Memory management improvements
- [x] Network handling changes
- [ ] SDK updates
- [ ] Build system changes

### Detailed Changes

#### Raw net message hooks
- C++: Added `Bridge_NetMessages_GetMessageNameById` — resolves message name via `FindNetworkMessageById` → `GetUnscopedName()`
- C++: Added `Bridge_NetMessages_GetCNetMessageSize` — returns compile-time `sizeof(CNetMessage)`, eliminating the hardcoded 48-byte offset
- C++: Fixed `FormatMoveDebugString` to parse `CCLCMsg_Move.data` via `bf_read` / `CSGOUserCmdPB`, matching the original CS2ServerGUI `ReadPBFromBuffer` logic
- C#: Added `GetMessageNameById`, `HookClientMessageRaw`, `HookServerMessageRaw`, `HookServerMessageInternalRaw` to `INetMessageService`
- C#: Implemented raw hook callback classes — auto-shift `CNetMessage*` → `google::protobuf::Message*` via `NativeNetMessages.GetCNetMessageSize()` at runtime
- C#: Added `NetMessageOffsets` doc constant + runtime `sizeof` bridge in `NetMessage.cs`

#### ConVar/Command enumeration & unlock
- C++: `Bridge_Convars_EnumerateConVars` / `Bridge_Commands_EnumerateCommands` — full iteration via `ICvar::FindCommandBase`
- C++: `Bridge_Convars_UnlockConVars` / `Bridge_Commands_UnlockCommands` — removes `FCVAR_HIDDEN | FCVAR_DEVELOPMENTONLY | FCVAR_DEFENSIVE`
- C#: `IConVarService.EnumerateConVars()` / `EnumerateCommands()` — returns name, description, flags, value
- C#: `IConVarService.UnlockConVars()` / `UnlockCommands()` — flag removal

#### Entity schema field walker
- C++: `Bridge_Schema_GetEntityFields` — walks all schema fields of an entity, returns JSON array with name, type, offset, value, and nested children
- C#: `IMemoryService.GetEntityFields(nint entity, string className)` — returns JSON string

#### Documentation
- Added CS2ServerGUI acknowledgement to `ACKNOWLEDGEMENTS.md`

## Testing

### Test Environment
- **OS**: Windows 11
- **Game**: Counter-Strike 2 (latest dedicated server)

### Test Cases

**Raw hooks:**
1. Player joining server — no crash, no access violation (previously crashed due to wrong pointer offset before `sizeof` fix)
2. API returned 200 events covering diverse message types: `CNETMsg_Tick`, `CCLCMsg_Move`, `CMsgSource1LegacyGameEvent`, `CCSUsrMsg_ProcessSpottedEntityUpdate`, `CNETMsg_NOP`, etc.
3. `DebugProtobuf` outputs readable protobuf `DebugString` — no garbled raw bytes
4. Offset integrity — `GetCNetMessageSize()` returns correct `sizeof(CNetMessage)` at compile time

**ConVar/Command enumeration:**
1. `EnumerateConVars()` returns full list with correct names, descriptions, flags, and values
2. `UnlockConVars()` / `UnlockCommands()` successfully removes hidden/development/defensive flags
3. Enumeration matches in-game `cvarlist` / `findflags` output

**Entity schema walker:**
1. `GetEntityFields()` returns valid JSON with field names, types, offsets, and values
2. Nested types (classes, arrays) are traversed recursively
3. Networked fields are correctly identified

### Real-world consumer

These APIs are used in production by **[CS2ServerGUI_SW2](https://github.com/nicedayzhu/CS2ServerGUI_SW2)** — a SwiftlyS2 port of the original [Source2ZE/CS2ServerGUI](https://github.com/Source2ZE/CS2ServerGUI). The plugin uses ConVar/Command enumeration + unlock, entity schema walking, and raw net message hooks (replacing 10 per-type typed hooks with 2 raw hooks):

```csharp
Core.NetMessage.HookClientMessageRaw((pid, msgId, pMessage) => {
    var name = Core.NetMessage.GetMessageNameById(msgId);
    var data = Core.Memory.DebugProtobuf(pMessage);
    LogIn(name, data, pid);
    return HookResult.Continue;
});
Core.NetMessage.HookServerMessageRaw((mask, msgId, pMessage) => {
    var name = Core.NetMessage.GetMessageNameById(msgId);
    var data = Core.Memory.DebugProtobuf(pMessage);
    LogOut(name, data);
    return HookResult.Continue;
});
```

## Breaking Changes

None. All existing APIs remain unchanged.

## Performance Impact

- [x] No performance impact

Raw hooks pass the same `CNetMessage*` pointer through the same C callback mechanism as typed hooks — no extra allocations or copies. ConVar/Command enumeration is O(n) over existing engine data structures.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![CS2ServerGUI_SW2 Web UI](https://raw.githubusercontent.com/nicedayzhu/CS2ServerGUI_SW2/master/web_img.png)

CS2ServerGUI_SW2 Web UI showing real-time event log with all network messages captured via raw hooks.
