### PR TITLE
fix: Correct KeyValues.SetString/GetString

### DIFF
--- a/managed/src/SwiftlyS2.Shared/Natives/Structs/KeyValues.cs
+++ b/managed/src/SwiftlyS2.Shared/Natives/Structs/KeyValues.cs
@@ -134,7 +134,9 @@ public unsafe struct KeyValues
         var key = FindKey(keyName);
         return key == null || key->DataType != KeyValuesDataType.TYPE_STRING
             ? defaultValue
-            : key->StringValue == nint.Zero ? string.Empty : Marshal.PtrToStringUTF8(key->StringValue)!;
+            : key->AllocatedExternalMemory
+            ? key->StringValue == nint.Zero ? string.Empty : Marshal.PtrToStringUTF8(key->StringValue)!
+            : Marshal.PtrToStringUTF8((nint)key)!;
     }
 
     public nint GetPtr( string keyName, nint defaultValue = 0 )
@@ -191,6 +193,7 @@ public unsafe struct KeyValues
 
         key->DataType = KeyValuesDataType.TYPE_STRING;
         key->StringValue = StringPool.Allocate(value);
+        key->AllocatedExternalMemory = true;
     }
 
     public void SetInt( string keyName, int value )


### PR DESCRIPTION
## Description

Brief description of the changes introduced by this pull request.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] Build/CI improvement

## Related Issues

Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)

## Changes Made

- [ ] Native changes (C++)
- [x] Managed Changes (C#)
- [ ] API additions/modifications
- [ ] Memory management improvements
- [ ] Network handling changes
- [ ] SDK updates
- [ ] Build system changes

### Detailed Changes

List the specific changes made:

- 
- 
- 

## Testing

### Test Environment

- **OS**: (e.g., Windows 11, Ubuntu 22.04)
- **Game**: (e.g., Counter-Strike 2)

### Test Cases

Describe the test cases you've run:

1. hook `CSource2Server::ApplyGameSettings` (offset 18), do `host_workshop_map 3343029934`
2. pKV->FindKey("map")->GetString("mapname");
3. result should be `kz_dima`

## Breaking Changes

List any breaking changes and migration steps:

- 
- 

## Performance Impact

- [x] No performance impact
- [ ] Positive performance impact
- [ ] Negative performance impact (explain below)
- [ ] Performance impact unknown

Details:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots/Videos (if applicable)

Add screenshots or videos demonstrating the changes:

## Additional Notes

Any additional information, context, or notes for reviewers:

Take a look on tier0 `CKeyValues_Data::Internal_SetString` and `CKeyValues_Data::Internal_GetString`
When KeyValues string length is less than 8, it will be embedded in KeyValues, not on external char*, just like 
`[FieldOffset(0)] public fixed char StringEmbeddedValue[8];`

---

### For Maintainers

- [ ] Code review completed
- [ ] Tests pass
- [ ] Ready to merge
