### PR TITLE
Respect ConfigurationKeyName when clearing collection defaults

### DIFF
--- a/managed/src/SwiftlyS2.Shared/SwiftlyCoreInjection.cs
+++ b/managed/src/SwiftlyS2.Shared/SwiftlyCoreInjection.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -106,6 +107,15 @@ public class SwiftlyOptionsFactory<T> : IOptionsFactory<T> where T : class, new(
         ClearCollectionsRecursive(instance, config);
     }
 
+    private static string GetConfigKey( PropertyInfo prop )
+    {
+        var configKeyAttr = prop.GetCustomAttribute<ConfigurationKeyNameAttribute>();
+        if ( configKeyAttr != null ) return configKeyAttr.Name;
+
+        var jsonAttr = prop.GetCustomAttribute<JsonPropertyNameAttribute>();
+        return jsonAttr != null ? jsonAttr.Name : prop.Name;
+    }
+
     private static void ClearCollectionsRecursive( object current, IConfiguration config )
     {
         foreach (var prop in current.GetType().GetProperties())
@@ -115,7 +125,7 @@ public class SwiftlyOptionsFactory<T> : IOptionsFactory<T> where T : class, new(
             var currentValue = prop.GetValue(current);
             if (currentValue == null) continue;
 
-            var section = config.GetSection(prop.Name);
+            var section = config.GetSection(GetConfigKey(prop));
 
             var hasConfigValue = section.Exists() && (section.GetChildren().Any() || section.Value != null);
 


### PR DESCRIPTION
## Description

Fixes collection default clearing for configuration properties that use custom configuration key names.

Previously, collection defaults were only cleared using the C# property name. This caused configured collection values to be appended to default values when the configuration used a custom key via `ConfigurationKeyNameAttribute`.

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Code refactoring (no functional changes)
* [ ] Performance improvement
* [ ] Test coverage improvement
* [ ] Build/CI improvement

## Related Issues

N/A

## Changes Made

* [ ] Native changes (C++)
* [x] Managed Changes (C#)
* [ ] API additions/modifications
* [ ] Memory management improvements
* [ ] Network handling changes
* [ ] SDK updates
* [ ] Build system changes

### Detailed Changes

* Added configuration key resolution for collection default clearing.
* Collection sections are now resolved using `ConfigurationKeyNameAttribute` when present.
* Added fallback key resolution using `JsonPropertyNameAttribute`, then the property name.
* Prevents configured collection values from being appended to default collection values when custom configuration keys are used.

## Testing

### Test Environment

* **OS**: Linux server
* **Game**: Counter-Strike 2

### Test Cases

Describe the test cases you've run:

1. Built the project with the managed changes.
2. Deployed the updated build to a Linux Counter-Strike 2 server.
3. Tested a plugin configuration model with a collection using `ConfigurationKeyNameAttribute`.
4. Confirmed configured collection values replace default collection values instead of being appended.
5. Confirmed plugin configuration still loads correctly after server startup/reload.

## Breaking Changes

None.

## Performance Impact

* [x] No performance impact
* [ ] Positive performance impact
* [ ] Negative performance impact (explain below)
* [ ] Performance impact unknown

Details:

Only adds small reflection-based key resolution during options creation, in the same path where collection defaults were already being inspected.

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots/Videos (if applicable)

N/A

## Additional Notes

This change does not alter the actual configuration binder behavior. `ConfigurationKeyNameAttribute` remains the correct attribute for binding custom configuration keys. `JsonPropertyNameAttribute` is only used as a fallback during collection default clearing.

---

### For Maintainers

* [ ] Code review completed
* [ ] Tests pass
* [ ] Ready to merge
