### PR TITLE
Remove 'ClientPutInServer' from confilter example.

### DIFF
--- a/plugin_files/configs/confilter.example.jsonc
+++ b/plugin_files/configs/confilter.example.jsonc
@@ -41,7 +41,6 @@
     "Framerate_Header": "excl ms   excl %   incl ms   group",
     "Framerate_Values": "\\d+\\.\\d+ms\\s+\\d+\\.\\d+%\\s+\\d+\\.\\d+ms\\s+[A-Za-z\\s]+",
     "Framerate_Total": "FrameTotal:\\s+\\d+\\.\\d+ms,\\s+\\s*tolerance:\\s+\\d+\\.\\d+ms",
-    "ClientPutInServer": "ClientPutInServer",
     "IGameSystem": "IGameSystem::",
     "FLASHBANG": "FLASHBANG:"
 }


### PR DESCRIPTION
Removed 'ClientPutInServer' entry from the configuration because when you try to log the event and use ClientPutInServer in the log message. You would think event is not working and will hit your head to the wall.