### PR TITLE
fix: add HH-mm-ss to log filenames to prevent collisions

### DIFF
--- a/managed/src/SwiftlyS2.Core/Misc/FileLogger.cs
+++ b/managed/src/SwiftlyS2.Core/Misc/FileLogger.cs
@@ -11,7 +11,7 @@ internal static class FileLogger
     private static Thread? _flushThread;
     private static volatile bool _running = false;
     private static string _logDirectory = string.Empty;
-    private static string _currentDate = string.Empty;
+    private static DateTime _currentDate;
 
     public static void Initialize( string basePath )
     {
@@ -27,8 +27,8 @@ internal static class FileLogger
         if (!Directory.Exists(_logDirectory))
             _ = Directory.CreateDirectory(_logDirectory);
 
-        _currentDate = DateTime.Now.ToString("yyyy-MM-dd");
-        _fileStream = new StreamWriter(Path.Combine(_logDirectory, $"{_currentDate}.log"), append: true);
+        _currentDate = DateTime.Now;
+        _fileStream = new StreamWriter(Path.Combine(_logDirectory, $"{_currentDate:yyyy-MM-dd_HH-mm-ss}.log"), append: true);
 
         _running = true;
         _flushThread = new Thread(() =>
@@ -48,15 +48,15 @@ internal static class FileLogger
 
     private static void RollDateIfNeeded()
     {
-        var today = DateTime.Now.ToString("yyyy-MM-dd");
-        if (today == _currentDate) return;
+        var now = DateTime.Now;
+        if (now.Date == _currentDate.Date) return;
         lock (_lock)
         {
-            if (today == _currentDate) return;
+            if (now.Date == _currentDate.Date) return;
             _fileStream?.Flush();
             _fileStream?.Dispose();
-            _currentDate = today;
-            _fileStream = new StreamWriter(Path.Combine(_logDirectory, $"{_currentDate}.log"), append: true);
+            _currentDate = now;
+            _fileStream = new StreamWriter(Path.Combine(_logDirectory, $"{now:yyyy-MM-dd_HH-mm-ss}.log"), append: true);
         }
     }
 

--- a/src/monitor/consolelogger/consolelogger.cpp
+++ b/src/monitor/consolelogger/consolelogger.cpp
@@ -59,15 +59,15 @@ static std::string GetTimestampString()
 static std::string GetDateString()
 {
     std::time_t now = std::time(nullptr);
-    char buf[16];
+    char buf[32];
 #ifdef _WIN32
     struct tm tm_info;
     localtime_s(&tm_info, &now);
-    std::strftime(buf, sizeof(buf), "%Y-%m-%d", &tm_info);
+    std::strftime(buf, sizeof(buf), "%Y-%m-%d_%H-%M-%S", &tm_info);
 #else
     struct tm tm_info;
     localtime_r(&now, &tm_info);
-    std::strftime(buf, sizeof(buf), "%Y-%m-%d", &tm_info);
+    std::strftime(buf, sizeof(buf), "%Y-%m-%d_%H-%M-%S", &tm_info);
 #endif
     return buf;
 }
@@ -195,7 +195,8 @@ void ConsoleLogger::WorkerThread()
             continue;
 
         std::string dayPath = GetDailyLogPath();
-        if (dayPath != m_currentLogFile)
+        // Compare only the yyyy-MM-dd prefix (10 chars after m_logDir)
+        if (dayPath.compare(m_logDir.size(), 10, m_currentLogFile, m_logDir.size(), 10) != 0)
             m_currentLogFile = dayPath;
 
         if (m_currentLogFile.empty())


### PR DESCRIPTION
## Description

Fix log filename collisions caused by day-only precision — affecting server restarts, hot reloads, and multi-instance deployments.

The `ManagedEnable` refactor (`ddbc37a50`) changed log filenames in both managed (C#) and native (C++) loggers from sub-second to day-only format (`yyyy-MM-dd.log`). When a second process or restart opens the same file within a day, it crashes with a file-lock error (`IOException` / `fopen` failure).

This PR restores sub-second precision (`yyyy-MM-dd_HH-mm-ss`) to both loggers.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes: log filename conflict when multiple CS2 server instances share the same addons directory.

## Changes Made

- [x] Native changes (C++)
- [x] Managed Changes (C#)

### Detailed Changes

- **Managed** (`FileLogger.cs`): Changed `_currentDate` type from `string` to `DateTime`, added `HH-mm-ss` to filename format. Date comparison in `RollDateIfNeeded()` uses `.Date` instead of string equality.
- **Native** (`consolelogger.cpp`): Changed `GetDateString()` buffer from 16 to 32 bytes, format from `%Y-%m-%d` to `%Y-%m-%d_%H-%M-%S`. Date-roll in `WorkerThread` preserved — compares only the `yyyy-MM-dd` prefix.
- Result: log files named `2026-07-01_21-23-06.log` instead of `2026-07-01.log`.

## Testing

### Before (Error)

Second instance crashes with `IOException` on startup:

```
System.IO.IOException: The process cannot access the file
'...\addons\swiftlys2\logs\managed\2026-07-01.log' because it is being used
by another process.
   at SwiftlyS2.Core.Misc.FileLogger.Initialize(string basePath) in
      /.../managed/src/SwiftlyS2.Core/Misc/FileLogger.cs:31
   at SwiftlyS2.Core.Bootstrap.Start(...) in
      /.../managed/src/SwiftlyS2.Core/Bootstrap.cs:67
```

### After (Fixed)

```
logs/console/2026-07-01_21-23-06.log   ← unique per startup
logs/managed/2026-07-01_21-23-06.log   ← unique per startup
```

### Test Cases

1. Single instance startup — verified both `logs/managed/` and `logs/console/` generate `yyyy-MM-dd_HH-mm-ss.log` format.
2. Two instances sharing the same addons directory — no longer crash on startup.
3. Server restart within same day — new timestamped file created, no conflict.
4. Managed: `dotnet build` passes with 0 errors.
5. Native: `xmake build swiftlys2` passes with 0 errors.

## Breaking Changes

None. Filename format changes but no public API or configuration is affected.

## Performance Impact

- [x] No performance impact

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional Notes

The native `swiftlys2.dll` and managed `SwiftlyS2.CS2.dll` both need to be updated for the fix to cover both log directories.
