### PR TITLE
docs(readme): fix SwiftlyS2 typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 SwiftlyS2 is a powerful scripting framework for Source 2 games, built in C++ with C# plugin support. It provides developers with a comprehensive API to create plugins for Source 2-based games like Counter-Strike 2.
 
-# Why should you choose SwifltyS2?
+# Why should you choose SwiftlyS2?
 
-SwifltyS2 is built with developers in mind, providing an extensive suite of scripting features that make plugin development faster and more efficient.
+SwiftlyS2 is built with developers in mind, providing an extensive suite of scripting features that make plugin development faster and more efficient.
 
 We're preventing memory leaks when working with the game's SDK and functions, having active maintenance and faster execution speeds through natives which are calling directly Native (core) code.
 


### PR DESCRIPTION
## Description

Fixes a typo in the README: SwifltyS2 → SwiftlyS2.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Related Issues

N/A

## Changes Made

- [ ] Native changes (C++)
- [ ] Managed Changes (C#)
- [ ] API additions/modifications

### Detailed Changes

- Corrected SwifltyS2 to SwiftlyS2 in the README intro heading and paragraph.

## Testing

### Test Environment

- N/A (docs only)

### Test Cases

1. Visual check of README rendering

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code