### PR TITLE
fix: Remove Swiftly core path from `GAME` search paths

### DIFF
--- a/src/engine/fixes/entrypoint.cpp
+++ b/src/engine/fixes/entrypoint.cpp
@@ -21,6 +21,8 @@
 #include <api/shared/plat.h>
 #include <api/interfaces/manager.h>
 
+#include <core/entrypoint.h>
+
 #include <public/filesystem.h>
 
 #include <fmt/format.h>
@@ -32,7 +34,9 @@ void StartFixes()
     auto filesystem = g_ifaceService.FetchInterface<IFileSystem>(FILESYSTEM_INTERFACE_VERSION);
 
     std::string csgo_path = fmt::format("{}{}csgo", Plat_GetGameDirectory(), WIN_LINUX("\\", "/"));
+    std::string swiftly_path = fmt::format("{}{}{}", csgo_path, WIN_LINUX("\\", "/"), g_SwiftlyCore.GetCorePath());
 
+    filesystem->RemoveSearchPath(swiftly_path.c_str(), "GAME");
     filesystem->RemoveSearchPaths("DEFAULT_WRITE_PATH");
     filesystem->AddSearchPath(csgo_path.c_str(), "DEFAULT_WRITE_PATH", PATH_ADD_TO_TAIL, SEARCH_PATH_PRIORITY_DEFAULT, 0);
 


### PR DESCRIPTION
## Description

Remove Swiftly core path from `GAME` search paths

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] Build/CI improvement

## Related Issues

Fixes #342
Closes #342
Related to https://github.com/swiftly-solution/swiftlys2/pull/339/changes/e1a7fd76803f56619928c9ab7117bdaa7ba52e68

## Changes Made

- [x] Native changes (C++)
- [ ] Managed Changes (C#)
- [ ] API additions/modifications
- [ ] Memory management improvements
- [ ] Network handling changes
- [ ] SDK updates
- [ ] Build system changes

### Detailed Changes

List the specific changes made:

- 
- 
- 

## Testing

### Test Environment

- **OS**: Windows
- **Game**: Counter-Strike 2

### Test Cases

Describe the test cases you've run:

1. 
2. 
3. 

## Breaking Changes

List any breaking changes and migration steps:

- 
- 

## Performance Impact

- [x] No performance impact
- [ ] Positive performance impact
- [ ] Negative performance impact (explain below)
- [ ] Performance impact unknown

Details:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots/Videos (if applicable)

Add screenshots or videos demonstrating the changes:

## Additional Notes

**Credits:**
https://github.com/alliedmodders/metamod-source/blob/0084b86af4b08614ed6b95485d072b5aa2e88cdc/core/provider/source2/provider_source2.cpp#L120-L126

---

### For Maintainers

- [ ] Code review completed
- [ ] Tests pass
- [ ] Ready to merge
