### PR TITLE
fix(TracePlayerBBox): store hull ray back into TraceParams

### DIFF
--- a/managed/src/SwiftlyS2.Core/Modules/Trace/TraceManager.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/Trace/TraceManager.cs
@@ -142,8 +142,11 @@ internal class TraceManager : ITraceManager
     public TraceResult TracePlayerBBox( in Vector start, in Vector end, in BBox_t bounds, in TraceParams? options = default )
     {
         var resolvedOptions = ResolveOptionsOrDefault(in options);
-        resolvedOptions.Ray.Init(bounds.Mins, bounds.Maxs);
-
+    
+        var ray = resolvedOptions.Ray;
+        ray.Init(bounds.Mins, bounds.Maxs);
+        resolvedOptions.Ray = ray;
+    
         return TraceShapeLine(in start, in end, resolvedOptions);
     }
 


### PR DESCRIPTION
## Description

Ray is a struct property, so resolvedOptions.Ray.Init() mutated a temporary copy that is discarded. The ray would stay RAY_TYPE_LINE and the bbox will be ignored, turning player hull traces into line traces. 

Instead copy the ray out, init it with the bounds, and assign it back so TraceShapeLine sweeps the actual hull.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #345

## Changes Made

- [X] Managed Changes (C#)

---

### For Maintainers

- [ ] Code review completed
- [ ] Tests pass
- [ ] Ready to merge
