### PR TITLE
fix(gamadata): Linux signature for ProcessMovement function

### DIFF
--- a/plugin_files/gamedata/cs2/core/signatures.jsonc
+++ b/plugin_files/gamedata/cs2/core/signatures.jsonc
@@ -373,7 +373,7 @@
     "CCSPlayer_MovementServices::ProcessMovement": {
         "lib": "server",
         "windows": "40 57 41 57 48 81 EC ? ? ? ? 48 83 79",
-        "linux": "55 48 89 E5 41 57 41 56 41 55 41 54 49 89 F4 53 48 89 FB 48 83 EC ? 48 8B 57"
+        "linux": "55 48 89 E5 41 57 41 56 41 55 49 89 F5 41 54 53 48 89 FB 48 83 EC ? 48 8B 7F"
     },
     // Via dev_create_move_report ref
     "CCSPlayer_MovementServices::SetupMove": {


### PR DESCRIPTION
## Description

The Linux signature for `CCSPlayer_MovementServices::ProcessMovement` actually matches `CCSObserver_MovementServices::ProcessMovement`, the spectator version of the same function. Both classes override the same vtable slot, so the mix up is easy to make and invisible since the signature resolves fine, just to the wrong function.

Result: `GameHooks.Movement.ProcessMovement` Pre/Post never fire for actual players on Linux, no error, it just silently does nothing. Windows is fine.

PR swaps the Linux pattern for one that matches the real player function (pattern from Source2ZE/CS2Fixes). The bug has been there since the signature was added (v1.3.5) through v1.4.5.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

### Detailed Changes

- `plugin_files/gamedata/cs2/core/signatures.jsonc` - Linux pattern for `"CCSPlayer_MovementServices::ProcessMovement"`:
  - Old: `55 48 89 E5 41 57 41 56 41 55 41 54 49 89 F4 53 48 89 FB 48 83 EC ? 48 8B 57`
  - New: `55 48 89 E5 41 57 41 56 41 55 49 89 F5 41 54 53 48 89 FB 48 83 EC ? 48 8B 7F`

## Testing

### Test Environment

- **OS**: Linux
- **Game**: Counter-Strike 2 (current build, 1.41.7.7)

### Test Cases

Found while migrating a surf timer plugin's frametime scaling to `GameHooks.Movement.ProcessMovement`. It silently stopped working on Linux, and everything on the managed side checked out, so I doubled checked the sig against others (mine/CS2Fixes) and noticed the Swiftly one didn't match.

1. Checked which class owns each matched function. Both patterns match exactly one address in `libserver.so`. Followed the vtables back from each address, the old pattern function belongs to `CCSObserver_MovementServices`, the new one to `CCSPlayer_MovementServices`, same vtable slot (29) on both classes. I.e. the old signature grabbed the observer's override of the function it meant to hook.

2. Your gamedata comment agrees, saying the function contains `"following entity %d"` and `"PlayerMovementTraces"`. The new pattern function contains both. The old pattern function only contains the first one. So the comment always described the correct function, only the pattern missed. Comment needs no change.

3. Checked in-game before/after. Used my timer plugin that scales `gpGlobals->frametime` in ProcessMovement Pre/Post (fast-forward / slow-motion styles). With the old pattern the handlers never fire, no speed change. With the new pattern the handlers fire, styles work.

4. I did the same check over all 24 `CCSPlayer_MovementServices` gamedata entries, this was the only bad one.

## Breaking Changes

- None.

## Performance Impact

- [x] No performance impact

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules