### PR TITLE
docs(examples/sound): SourceEntityIndex modes and where position applies

### DIFF
--- a/managed/SwiftlyS2.PluginTemplate/templates/examples/SoundEvent.example.cs
+++ b/managed/SwiftlyS2.PluginTemplate/templates/examples/SoundEvent.example.cs
@@ -14,9 +14,10 @@ public partial class PluginId {
       // Set the soundevent name.
       Name = "Weapon_AK47.Single",
 
-      // Set the source entity,
-      // can be get by entity.Index,
-      // or set to -1 for emitting at recipient location (by default)
+      // Where the sound plays from.
+      // -1, the default, plays it at each recipient.
+      // 0 plays it at public.position in the world.
+      // Any other index attaches it to that entity, from entity.Index.
       SourceEntityIndex = -1,
 
       // Control the volume.
@@ -24,18 +25,26 @@ public partial class PluginId {
 
       // Control the pitch.
       Pitch = 2f
-
-
     };
-
-    // More param can be set.
-    soundEvent.SetFloat3("public.position", 1.0f, 1.0f, 1.0f);
 
     // Don't forget to add recipients.
     soundEvent.Recipients.AddAllPlayers();
 
     // Emit the sound event.
     soundEvent.Emit();
-    
+
+    // More params can be set. public.position places the sound somewhere in the
+    // world, which needs the source entity to be 0. At -1 the sound already plays
+    // at the listener, and on an entity it follows that entity instead, so the
+    // position is ignored in both of those.
+    using var positioned = new SoundEvent() {
+      Name = "Weapon_AK47.Single",
+      SourceEntityIndex = 0
+    };
+
+    positioned.SetFloat3("public.position", 0.0f, 0.0f, 0.0f);
+    positioned.Recipients.AddAllPlayers();
+    positioned.Emit();
+
   }
 }


### PR DESCRIPTION
The sound example sets `public.position` while `SourceEntityIndex` is -1, where the position is ignored, so the line it demonstrates does nothing.

`SourceEntityIndex` is what decides whether the position is used, and it has three modes rather than two:

| | |
|---|---|
| -1, the default | plays at each recipient, `public.position` is ignored |
| 0 | plays at `public.position` in the world |
| any entity index | attached to that entity and follows it |

Zero is how the game emits placed sounds, which is visible in its own messages: they carry an entity index of 0 together with real map coordinates.

Checked on v1.4.5 with a plugin written against this API, playing `Weapon_AK47.Single` four ways on a listening server. At -1 with the position set 2500 units aside it still plays at the listener. At 0 the same position moves it off to the side, and further out it drops away with distance.

The example now documents the three modes and shows the position in the mode where it does something.

If you would find it useful, I can follow up with a `Position` property on `SoundEvent` that sets the source entity to 0 for you, so this is harder to get wrong than through `SetFloat3`. Left out here since it changes `SourceEntityIndex` behind the caller's back, which is your call rather than mine.
