### PR TITLE
fix: Schema.GetString/GetCUtlString throw on unset string fields instead of returning empty

### DIFF
--- a/managed/src/SwiftlyS2.Core/Modules/Schemas/Schema.cs
+++ b/managed/src/SwiftlyS2.Core/Modules/Schemas/Schema.cs
@@ -110,17 +110,13 @@ internal static class Schema
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string GetString( nint handle )
     {
-        if (handle == 0) throw new InvalidOperationException("Schema instance cannot be null.");
-
-        return Marshal.PtrToStringUTF8(handle) ?? string.Empty;
+        return handle == 0 ? string.Empty : Marshal.PtrToStringUTF8(handle) ?? string.Empty;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string GetCUtlString( nint handle )
     {
-        if (handle == 0) throw new InvalidOperationException("Schema instance cannot be null.");
-
-        return Marshal.PtrToStringUTF8(handle) ?? string.Empty;
+        return handle == 0 ? string.Empty : Marshal.PtrToStringUTF8(handle) ?? string.Empty;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Description

Reading a string schema property that was never set (e.g. `CCSPlayerController.Clan` on a newly connected player) throws `InvalidOperationException: Schema instance cannot be null.`, even though the entity is perfectly valid. The string pointer inside it is simply still null, which is the normal default state.

This PR makes Schema.GetString and Schema.GetCUtlString return an empty string for a null pointer instead of throwing, matching how the game itself treats unset string fields. Fixes all generated string getters at once, with no regeneration needed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- [x] Managed Changes (C#)

### Detailed Changes

- `Schema.GetString`: null string pointer now returns `string.Empty` instead of throwing
- `Schema.GetCUtlString`: same

The old exception message was also misleading. At these call sites the argument is the already dereferenced string pointer, never the schema instance. A real null instance would be caught earlier anyway, and the instance level helpers (`Update`, `SetString`, `SetFixedString`, `SetCUtlString`) keep their guards unchanged.

## Testing

### Test Environment

- **OS**: Ubuntu 24.04
- **Game**: Counter-Strike 2

### Test Cases

1. Reading `Controller.Clan` on a newly connected player no longer throws, returns empty string
2. Build passes with no new warnings

## Performance Impact

- [x] No performance impact

## Additional Notes

Noticed this while debugging a tags plugin that read `Controller.Clan` before ever writing it, the read threw on every player connect. Any plugin reading a pointer backed string property before first write hits this.